### PR TITLE
Required callback, or knex times out waiting

### DIFF
--- a/src/blockchain/log-processors/designated-report-submitted.ts
+++ b/src/blockchain/log-processors/designated-report-submitted.ts
@@ -3,5 +3,7 @@ import * as Knex from "knex";
 import { FormattedLog, ErrorCallback } from "../../types";
 
 export function processDesignatedReportSubmittedLog(db: Knex, augur: Augur, trx: Knex.Transaction, log: FormattedLog, callback: ErrorCallback): void {
-
+    console.log("TODO: DesignatedReportSubmitted");
+    console.log(log);
+    callback(null);
 }

--- a/src/blockchain/log-processors/market-finalized.ts
+++ b/src/blockchain/log-processors/market-finalized.ts
@@ -3,5 +3,7 @@ import * as Knex from "knex";
 import { FormattedLog, ErrorCallback } from "../../types";
 
 export function processMarketFinalizedLog(db: Knex, augur: Augur, trx: Knex.Transaction, log: FormattedLog, callback: ErrorCallback): void {
-
+    console.log("TODO: MarketFinalized");
+    console.log(log);
+    callback(null);
 }

--- a/src/blockchain/log-processors/order-filled.ts
+++ b/src/blockchain/log-processors/order-filled.ts
@@ -11,5 +11,7 @@ interface Trade {
 }
 
 export function processOrderFilledLog(db: Knex, augur: Augur, trx: Knex.Transaction, log: FormattedLog, callback: ErrorCallback): void {
-
+  console.log("TODO: OrderFilled");
+  console.log(log);
+  callback(null);
 }

--- a/src/blockchain/log-processors/proceeds-claimed.ts
+++ b/src/blockchain/log-processors/proceeds-claimed.ts
@@ -3,5 +3,7 @@ import * as Knex from "knex";
 import { FormattedLog, ErrorCallback } from "../../types";
 
 export function processProceedsClaimedLog(db: Knex, augur: Augur, trx: Knex.Transaction, log: FormattedLog, callback: ErrorCallback): void {
-
+    console.log("TODO: ProceedsClaimed");
+    console.log(log);
+    callback(null);
 }

--- a/src/blockchain/log-processors/report-submitted.ts
+++ b/src/blockchain/log-processors/report-submitted.ts
@@ -3,5 +3,7 @@ import * as Knex from "knex";
 import { FormattedLog, ErrorCallback } from "../../types";
 
 export function processReportSubmittedLog(db: Knex, augur: Augur, trx: Knex.Transaction, log: FormattedLog, callback: ErrorCallback): void {
-
+    console.log("TODO: ReportSubmitted");
+    console.log(log);
+    callback(null);
 }

--- a/src/blockchain/log-processors/reports-disputed.ts
+++ b/src/blockchain/log-processors/reports-disputed.ts
@@ -3,5 +3,7 @@ import * as Knex from "knex";
 import { FormattedLog, ErrorCallback } from "../../types";
 
 export function processReportsDisputedLog(db: Knex, augur: Augur, trx: Knex.Transaction, log: FormattedLog, callback: ErrorCallback): void {
-
+    console.log("TODO: ReportsDisputed");
+    console.log(log);
+    callback(null);
 }

--- a/src/blockchain/log-processors/universe-forked.ts
+++ b/src/blockchain/log-processors/universe-forked.ts
@@ -3,5 +3,7 @@ import * as Knex from "knex";
 import { FormattedLog, ErrorCallback } from "../../types";
 
 export function processUniverseForkedLog(db: Knex, augur: Augur, trx: Knex.Transaction, log: FormattedLog, callback: ErrorCallback): void {
-
+    console.log("TODO: UniverseForked");
+    console.log(log);
+    callback(null);
 }

--- a/src/blockchain/log-processors/winning-tokens-redeemed.ts
+++ b/src/blockchain/log-processors/winning-tokens-redeemed.ts
@@ -3,5 +3,7 @@ import * as Knex from "knex";
 import { FormattedLog, ErrorCallback } from "../../types";
 
 export function processWinningTokensRedeemedLog(db: Knex, augur: Augur, trx: Knex.Transaction, log: FormattedLog, callback: ErrorCallback): void {
-
+    console.log("TODO: WinningTokensRedeemed");
+    console.log(log);
+    callback(null);
 }


### PR DESCRIPTION
Really simple PR, but without `callback(null)`, calling an unimplemented log processor causes Knex to hang up/error:

```
Unhandled rejection TimeoutError: Knex: Timeout acquiring a connection. The pool is probably full. Are you missing a .transacting(trx) call?
debuggability.js:868
    at Timeout._onTimeout (/Users/epheph/augur/augur-node/node_modules/knex/lib/client.js:287:18)
    at ontimeout (timers.js:471:11)
    at tryOnTimeout (timers.js:306:5)
    at Timer.listOnTimeout (timers.js:266:5)
```

We haven't run into this yet, because there wasn't an integration of the test emitting contract.