### PR TITLE
centralize join logic for markets

### DIFF
--- a/src/server/getters/database.ts
+++ b/src/server/getters/database.ts
@@ -1,0 +1,9 @@
+import { QueryBuilder } from "knex";
+import { sortDirection } from "../../utils/sort-direction";
+
+export function queryModifier(query: QueryBuilder, defaultSortBy: string, defaultSortOrder: string, sortBy: string|null|undefined, isSortDescending: boolean|null|undefined, limit: number|null|undefined, offset: number|null|undefined): QueryBuilder {
+  query = query.orderBy(sortBy || defaultSortBy, sortDirection(isSortDescending, defaultSortOrder));
+  if (limit != null) query = query.limit(limit);
+  if (offset != null) query = query.offset(offset);
+  return query;
+}

--- a/src/server/getters/database.ts
+++ b/src/server/getters/database.ts
@@ -1,9 +1,71 @@
-import { QueryBuilder } from "knex";
+import * as Knex from "knex";
+import BigNumber from "bignumber.js";
 import { sortDirection } from "../../utils/sort-direction";
+import { MarketsRowWithCreationTime, OutcomesRow, UIMarketInfo, UIConsensusInfo, UIOutcomeInfo } from "../../types";
 
-export function queryModifier(query: QueryBuilder, defaultSortBy: string, defaultSortOrder: string, sortBy: string|null|undefined, isSortDescending: boolean|null|undefined, limit: number|null|undefined, offset: number|null|undefined): QueryBuilder {
+export function queryModifier(query: Knex.QueryBuilder, defaultSortBy: string, defaultSortOrder: string, sortBy: string|null|undefined, isSortDescending: boolean|null|undefined, limit: number|null|undefined, offset: number|null|undefined): Knex.QueryBuilder {
   query = query.orderBy(sortBy || defaultSortBy, sortDirection(isSortDescending, defaultSortOrder));
   if (limit != null) query = query.limit(limit);
   if (offset != null) query = query.offset(offset);
   return query;
+}
+
+export function reshapeOutcomesRowToUIOutcomeInfo(outcomesRow: OutcomesRow): UIOutcomeInfo {
+  const outcomeInfo: UIOutcomeInfo = {
+    id: outcomesRow.outcome,
+    outstandingShares: outcomesRow.sharesOutstanding,
+    price: outcomesRow.price,
+  };
+  return outcomeInfo;
+}
+
+export function reshapeMarketsRowToUIMarketInfo(row: MarketsRowWithCreationTime, outcomesInfo: Array<UIOutcomeInfo>): UIMarketInfo {
+  let consensus: UIConsensusInfo|null;
+  if (row.consensusOutcome === null) {
+    consensus = null;
+  } else {
+    consensus = { outcomeID: row.consensusOutcome, isIndeterminate: row.isInvalid } as UIConsensusInfo;
+  }
+  const marketInfo: UIMarketInfo = {
+    id: row.marketID,
+    universe: row.universe,
+    type: row.marketType,
+    numOutcomes: row.numOutcomes,
+    minPrice: row.minPrice,
+    maxPrice: row.maxPrice,
+    cumulativeScale: new BigNumber(row.maxPrice, 10).minus(new BigNumber(row.minPrice, 10)).toFixed(),
+    author: row.marketCreator,
+    creationTime: row.creationTime,
+    creationBlock: row.creationBlockNumber,
+    creationFee: row.creationFee,
+    reportingFeeRate: row.reportingFeeRate,
+    marketCreatorFeeRate: row.marketCreatorFeeRate,
+    marketCreatorFeesCollected: row.marketCreatorFeesCollected,
+    category: row.category,
+    tags: [row.tag1, row.tag2],
+    volume: row.volume,
+    outstandingShares: row.sharesOutstanding,
+    reportingWindow: row.reportingWindow,
+    endDate: row.endTime,
+    finalizationTime: row.finalizationTime,
+    reportingState: row.reportingState,
+    description: row.shortDescription,
+    extraInfo: row.longDescription,
+    designatedReporter: row.designatedReporter,
+    designatedReportStake: row.designatedReportStake,
+    resolutionSource: row.resolutionSource,
+    numTicks: row.numTicks,
+    consensus,
+    outcomes: outcomesInfo,
+  };
+  return marketInfo;
+}
+
+export function getMarketsWithReportingState(db: Knex, selectColumns?: Array<string>): Knex.QueryBuilder {
+  // TODO: turn leftJoin() into join() once we take care of market_state on market creation
+  const columns = selectColumns ? selectColumns.slice() : ["markets.*"];
+  return db.select(columns.concat("market_state.reportingState", "blocks.timestamp as creationTime"))
+    .from("markets")
+    .leftJoin("market_state", "markets.marketStateID", "market_state.marketStateID")
+    .leftJoin("blocks", "markets.creationBlockNumber", "blocks.blockNumber");
 }

--- a/src/server/getters/get-account-transfer-history.ts
+++ b/src/server/getters/get-account-transfer-history.ts
@@ -1,6 +1,6 @@
 import * as Knex from "knex";
 import { Address, Bytes32 } from "../../types";
-import { sortDirection } from "../../utils/sort-direction";
+import { queryModifier } from "./database";
 
 export interface TransferRow {
   transactionHash: Bytes32;
@@ -15,8 +15,6 @@ export interface TransferRow {
 export function getAccountTransferHistory(db: Knex, account: Address, token: Address|null|undefined, sortBy: string|null|undefined, isSortDescending: boolean|null|undefined, limit: number|null|undefined, offset: number|null|undefined, callback: (err: Error|null, transferHistory?: Array<TransferRow>) => void): void {
   let query = db("transfers").where((db: Knex): Knex.QueryBuilder => db.where("sender", account).orWhere("recipient", account));
   if (token != null) query = query.andWhere({ token });
-  query = query.orderBy(sortBy || "blockNumber", sortDirection(isSortDescending, "desc"));
-  if (limit != null) query = query.limit(limit);
-  if (offset != null) query = query.offset(offset);
+  query = queryModifier(query, "blockNumber", "desc", sortBy, isSortDescending, limit, offset);
   query.asCallback(callback);
 }

--- a/src/server/getters/get-categories.ts
+++ b/src/server/getters/get-categories.ts
@@ -1,6 +1,6 @@
 import * as Knex from "knex";
 import { Address } from "../../types";
-import { sortDirection } from "../../utils/sort-direction";
+import { queryModifier } from "./database";
 
 export interface CategoriesRow {
   category: string;
@@ -9,9 +9,7 @@ export interface CategoriesRow {
 
 export function getCategories(db: Knex, universe: Address, sortBy: string|null|undefined, isSortDescending: boolean|null|undefined, limit: number|null|undefined, offset: number|null|undefined, callback: (err: Error|null, result?: Array<CategoriesRow>) => void): void {
   let query = db.select(["category", "popularity"]).from("categories").where({ universe });
-  query = query.orderBy(sortBy || "popularity", sortDirection(isSortDescending, "desc"));
-  if (limit != null) query = query.limit(limit);
-  if (offset != null) query = query.offset(offset);
+  query = queryModifier(query, "popularity", "desc", sortBy, isSortDescending, limit, offset);
   query.asCallback((err: Error|null, categoriesInfo?: Array<CategoriesRow>): void => {
     if (err) return callback(err);
     if (!categoriesInfo) return callback(null);

--- a/src/server/getters/get-disputable-markets.ts
+++ b/src/server/getters/get-disputable-markets.ts
@@ -1,10 +1,7 @@
 import * as Knex from "knex";
 import { Address } from "../../types";
-import { sortDirection } from "../../utils/sort-direction";
 
 // Look up all markets that are currently able to be disputed. Response should include the value of the bond needed to actually dispute the result.
 export function getDisputableMarkets(db: Knex, reportingWindow: Address, sortBy: string|null|undefined, isSortDescending: boolean|null|undefined, limit: number|null|undefined, offset: number|null|undefined, callback: (err: Error|null, result?: any) => void): void {
-  // query = query.orderBy(sortBy || "volume", sortDirection(isSortDescending, "desc"));
-  // if (limit != null) query = query.limit(limit);
-  // if (offset != null) query = query.offset(offset);
+  //   query = queryModifier(query, sortBy || "volume", isSortDescending, limit, offset);
 }

--- a/src/server/getters/get-market-info.ts
+++ b/src/server/getters/get-market-info.ts
@@ -55,8 +55,8 @@ export function reshapeMarketsRowToUIMarketInfo(row: MarketsRowWithCreationTime,
 
 export function getMarketsWithReportingState(db: Knex, selectColumns?: Array<string>): Knex.QueryBuilder {
   // TODO: turn leftJoin() into join() once we take care of market_state on market creation
-  const columns = selectColumns ? selectColumns.slice() : ["markets.*", "blocks.timestamp as creationTime"];
-  return db.select(columns.concat("market_state.reportingState"))
+  const columns = selectColumns ? selectColumns.slice() : ["markets.*"];
+  return db.select(columns.concat("market_state.reportingState", "blocks.timestamp as creationTime"))
     .from("markets")
     .leftJoin("market_state", "markets.marketStateID", "market_state.marketStateID")
     .leftJoin("blocks", "markets.creationBlockNumber", "blocks.blockNumber");

--- a/src/server/getters/get-market-info.ts
+++ b/src/server/getters/get-market-info.ts
@@ -1,66 +1,6 @@
-import BigNumber from "bignumber.js";
 import * as Knex from "knex";
 import { Address, MarketsRowWithCreationTime, OutcomesRow, UIMarketInfo, UIConsensusInfo, UIOutcomeInfo } from "../../types";
-
-export function reshapeOutcomesRowToUIOutcomeInfo(outcomesRow: OutcomesRow): UIOutcomeInfo {
-  const outcomeInfo: UIOutcomeInfo = {
-    id: outcomesRow.outcome,
-    outstandingShares: outcomesRow.sharesOutstanding,
-    price: outcomesRow.price,
-  };
-  return outcomeInfo;
-}
-
-export function reshapeMarketsRowToUIMarketInfo(row: MarketsRowWithCreationTime, outcomesInfo: Array<UIOutcomeInfo>): UIMarketInfo {
-  let consensus: UIConsensusInfo|null;
-  if (row.consensusOutcome === null) {
-    consensus = null;
-  } else {
-    consensus = { outcomeID: row.consensusOutcome, isIndeterminate: row.isInvalid } as UIConsensusInfo;
-  }
-  const marketInfo: UIMarketInfo = {
-    id: row.marketID,
-    universe: row.universe,
-    type: row.marketType,
-    numOutcomes: row.numOutcomes,
-    minPrice: row.minPrice,
-    maxPrice: row.maxPrice,
-    cumulativeScale: new BigNumber(row.maxPrice, 10).minus(new BigNumber(row.minPrice, 10)).toFixed(),
-    author: row.marketCreator,
-    creationTime: row.creationTime,
-    creationBlock: row.creationBlockNumber,
-    creationFee: row.creationFee,
-    reportingFeeRate: row.reportingFeeRate,
-    marketCreatorFeeRate: row.marketCreatorFeeRate,
-    marketCreatorFeesCollected: row.marketCreatorFeesCollected,
-    category: row.category,
-    tags: [row.tag1, row.tag2],
-    volume: row.volume,
-    outstandingShares: row.sharesOutstanding,
-    reportingWindow: row.reportingWindow,
-    endDate: row.endTime,
-    finalizationTime: row.finalizationTime,
-    reportingState: row.reportingState,
-    description: row.shortDescription,
-    extraInfo: row.longDescription,
-    designatedReporter: row.designatedReporter,
-    designatedReportStake: row.designatedReportStake,
-    resolutionSource: row.resolutionSource,
-    numTicks: row.numTicks,
-    consensus,
-    outcomes: outcomesInfo,
-  };
-  return marketInfo;
-}
-
-export function getMarketsWithReportingState(db: Knex, selectColumns?: Array<string>): Knex.QueryBuilder {
-  // TODO: turn leftJoin() into join() once we take care of market_state on market creation
-  const columns = selectColumns ? selectColumns.slice() : ["markets.*"];
-  return db.select(columns.concat("market_state.reportingState", "blocks.timestamp as creationTime"))
-    .from("markets")
-    .leftJoin("market_state", "markets.marketStateID", "market_state.marketStateID")
-    .leftJoin("blocks", "markets.creationBlockNumber", "blocks.blockNumber");
-}
+import { reshapeMarketsRowToUIMarketInfo, reshapeOutcomesRowToUIOutcomeInfo, getMarketsWithReportingState } from "./database";
 
 export function getMarketInfo(db: Knex, marketID: string, callback: (err: Error|null, result?: UIMarketInfo) => void): void {
   getMarketsWithReportingState(db).where({ "markets.marketID": marketID }).limit(1).asCallback((err: Error | null, rows?: Array<MarketsRowWithCreationTime>): void => {

--- a/src/server/getters/get-market-info.ts
+++ b/src/server/getters/get-market-info.ts
@@ -63,7 +63,7 @@ export function getMarketsWithReportingState(db: Knex, selectColumns?: Array<str
 }
 
 export function getMarketInfo(db: Knex, marketID: string, callback: (err: Error|null, result?: UIMarketInfo) => void): void {
-  getMarketsWithReportingState(db).from("markets").where({ "markets.marketID": marketID }).limit(1).asCallback((err: Error | null, rows?: Array<MarketsRowWithCreationTime>): void => {
+  getMarketsWithReportingState(db).where({ "markets.marketID": marketID }).limit(1).asCallback((err: Error | null, rows?: Array<MarketsRowWithCreationTime>): void => {
     if (err) return callback(err);
     if (!rows || !rows.length) return callback(null);
     const marketsRow: MarketsRowWithCreationTime = rows[0];

--- a/src/server/getters/get-market-price-history.ts
+++ b/src/server/getters/get-market-price-history.ts
@@ -1,6 +1,6 @@
 import * as Knex from "knex";
 import { Address, TimestampedPrice, MarketPriceHistory } from "../../types";
-import { sortDirection } from "../../utils/sort-direction";
+import { queryModifier } from "./database";
 
 interface MarketPriceHistoryRow {
   outcome: number;
@@ -15,9 +15,8 @@ export function getMarketPriceHistory(db: Knex, marketID: Address|null|undefined
     "trades.outcome",
     "trades.price",
     "blocks.timestamp",
-  ]).from("trades").leftJoin("blocks", "trades.blockNumber", "blocks.blockNumber").where({ marketID }).orderBy(sortBy || "blocks.timestamp", sortDirection(isSortDescending, "desc"));
-  if (limit != null) query = query.limit(limit);
-  if (offset != null) query = query.offset(offset);
+  ]).from("trades").leftJoin("blocks", "trades.blockNumber", "blocks.blockNumber").where({ marketID });
+  query = queryModifier(query, "blocks.timestamp", "desc", sortBy, isSortDescending, limit, offset);
   query.asCallback((err: Error|null, tradesRows?: Array<MarketPriceHistoryRow>): void => {
     if (err) return callback(err);
     if (!tradesRows || !tradesRows.length) return callback(null);

--- a/src/server/getters/get-markets-awaiting-designated-reporting.ts
+++ b/src/server/getters/get-markets-awaiting-designated-reporting.ts
@@ -2,7 +2,7 @@ import { each } from "async";
 import * as Knex from "knex";
 import { Address, MarketsContractAddressRow, UIMarketInfo, UIMarketsInfo, ErrorCallback } from "../../types";
 import { reshapeMarketsRowToUIMarketInfo, getMarketsWithReportingState } from "./get-market-info";
-import { sortDirection } from "../../utils/sort-direction";
+import { queryModifier } from "./database";
 
 // Look up all markets that are currently awaiting designated (automated) reporting.
 // Should accept a designatedReporterAddress parameter that filters by designated reporter address.
@@ -12,9 +12,7 @@ export function getMarketsAwaitingDesignatedReporting(db: Knex, designatedReport
   let query = getMarketsWithReportingState(db, ["markets.marketID"]).whereNull("markets.marketStateID");
   if (designatedReporter != null) query = query.where({ designatedReporter });
 
-  query = query.orderBy(sortBy || "endTime", sortDirection(isSortDescending, "desc"));
-  if (limit != null) query = query.limit(limit);
-  if (offset != null) query = query.offset(offset);
+  query = queryModifier(query, "endTime", "desc", sortBy, isSortDescending, limit, offset);
   query.asCallback((err?: Error|null, marketsRows?: Array<MarketsContractAddressRow>): void => {
     if (err) return callback(err);
     if (!marketsRows) return callback(null);

--- a/src/server/getters/get-markets-awaiting-designated-reporting.ts
+++ b/src/server/getters/get-markets-awaiting-designated-reporting.ts
@@ -1,8 +1,7 @@
 import { each } from "async";
 import * as Knex from "knex";
 import { Address, MarketsContractAddressRow, UIMarketInfo, UIMarketsInfo, ErrorCallback } from "../../types";
-import { reshapeMarketsRowToUIMarketInfo, getMarketsWithReportingState } from "./get-market-info";
-import { queryModifier } from "./database";
+import { queryModifier, reshapeMarketsRowToUIMarketInfo, getMarketsWithReportingState } from "./database";
 
 // Look up all markets that are currently awaiting designated (automated) reporting.
 // Should accept a designatedReporterAddress parameter that filters by designated reporter address.

--- a/src/server/getters/get-markets-awaiting-reporting.ts
+++ b/src/server/getters/get-markets-awaiting-reporting.ts
@@ -1,7 +1,6 @@
 import * as Knex from "knex";
 import { Address, MarketsContractAddressRow, UIMarketInfo, UIMarketsInfo, ErrorCallback } from "../../types";
-import { reshapeMarketsRowToUIMarketInfo, getMarketsWithReportingState } from "./get-market-info";
-import { queryModifier } from "./database";
+import { queryModifier, reshapeMarketsRowToUIMarketInfo, getMarketsWithReportingState } from "./database";
 
 // Look up all markets that are currently available for limited reporting.
 // Must be able to sort by number of reports submitted for each market so far, and the response should include the number of reports already submitted -- as well as the payoutNumerator values of each of the reports + the amount staked on each -- as part of the response.

--- a/src/server/getters/get-markets-awaiting-reporting.ts
+++ b/src/server/getters/get-markets-awaiting-reporting.ts
@@ -1,7 +1,7 @@
 import * as Knex from "knex";
 import { Address, MarketsContractAddressRow, UIMarketInfo, UIMarketsInfo, ErrorCallback } from "../../types";
 import { reshapeMarketsRowToUIMarketInfo, getMarketsWithReportingState } from "./get-market-info";
-import { sortDirection } from "../../utils/sort-direction";
+import { queryModifier } from "./database";
 
 // Look up all markets that are currently available for limited reporting.
 // Must be able to sort by number of reports submitted for each market so far, and the response should include the number of reports already submitted -- as well as the payoutNumerator values of each of the reports + the amount staked on each -- as part of the response.
@@ -10,9 +10,7 @@ export function getMarketsAwaitingReporting(db: Knex, reportingWindow: Address|n
   if (reportingWindow != null) query = query.where({ reportingWindow });
   if (reportingState != null) query = query.where({ reportingState });
 
-  query = query.orderBy(sortBy || "volume", sortDirection(isSortDescending, "desc"));
-  if (limit != null) query = query.limit(limit);
-  if (offset != null) query = query.offset(offset);
+  query = queryModifier(query, "volume", "desc", sortBy, isSortDescending, limit, offset);
 
   // TODO: should we also consider a market_state's reportingState IS NULL?
   query.asCallback((err?: Error|null, marketsRows?: Array<MarketsContractAddressRow>): void => {

--- a/src/server/getters/get-markets-closing-in-date-range.ts
+++ b/src/server/getters/get-markets-closing-in-date-range.ts
@@ -1,14 +1,12 @@
 import * as Knex from "knex";
 import { Address, MarketsContractAddressRow } from "../../types";
-import { sortDirection } from "../../utils/sort-direction";
+import { queryModifier } from "./database";
 
 // Input: Date Range
 // Output: Markets Closing in Range
 export function getMarketsClosingInDateRange(db: Knex, earliestClosingTime: number, latestClosingTime: number, universe: Address, sortBy: string|null|undefined, isSortDescending: boolean|null|undefined, limit: number|null|undefined, offset: number|null|undefined, callback: (err: Error|null, result?: any) => void): void {
   let query = db.select("marketID").from("markets").whereRaw(`"endTime" >= ? AND "endTime" <= ? AND universe = ?`, [earliestClosingTime, latestClosingTime, universe]);
-  query = query.orderBy(sortBy || "endTime", sortDirection(isSortDescending, "desc"));
-  if (limit != null) query = query.limit(limit);
-  if (offset != null) query = query.offset(offset);
+  query = queryModifier(query, "endTime", "desc", sortBy, isSortDescending, limit, offset);
   query.asCallback((err: Error|null, rows?: Array<MarketsContractAddressRow>): void => {
     if (err) return callback(err);
     if (!rows) return callback(null);

--- a/src/server/getters/get-markets-created-by-user.ts
+++ b/src/server/getters/get-markets-created-by-user.ts
@@ -1,13 +1,11 @@
 import * as Knex from "knex";
 import { Address, MarketsContractAddressRow } from "../../types";
-import { sortDirection } from "../../utils/sort-direction";
+import { queryModifier } from "./database";
 
 // Should return the total amount of fees earned so far by the market creator.
 export function getMarketsCreatedByUser(db: Knex, creator: Address, sortBy: string|null|undefined, isSortDescending: boolean|null|undefined, limit: number|null|undefined, offset: number|null|undefined, callback: (err: Error|null, result?: Array<Address>) => void): void {
   let query = db.select("marketID").from("markets").where({ marketCreator: creator });
-  query = query.orderBy(sortBy || "volume", sortDirection(isSortDescending, "desc"));
-  if (limit != null) query = query.limit(limit);
-  if (offset != null) query = query.offset(offset);
+  query = queryModifier(query, "volume", "desc", sortBy, isSortDescending, limit, offset);
   query.asCallback((err: Error|null, rows?: Array<MarketsContractAddressRow>): void => {
     if (err) return callback(err);
     if (!rows) return callback(null);

--- a/src/server/getters/get-markets-in-category.ts
+++ b/src/server/getters/get-markets-in-category.ts
@@ -1,12 +1,10 @@
 import * as Knex from "knex";
 import { Address, MarketsContractAddressRow } from "../../types";
-import { sortDirection } from "../../utils/sort-direction";
+import { queryModifier } from "./database";
 
 export function getMarketsInCategory(db: Knex, category: Address, sortBy: string|null|undefined, isSortDescending: boolean|null|undefined, limit: number|null|undefined, offset: number|null|undefined, callback: (err: Error|null, result?: Array<Address>) => void): void {
   let query: Knex.QueryBuilder = db.select("marketID").from("markets").where({ category });
-  query = query.orderBy(sortBy || "volume", sortDirection(isSortDescending, "desc"));
-  if (limit != null) query = query.limit(limit);
-  if (offset != null) query = query.offset(offset);
+  query = queryModifier(query, "volume", "desc", sortBy, isSortDescending, limit, offset);
   query.asCallback((err: Error|null, marketsInCategory?: Array<MarketsContractAddressRow>): void => {
     if (err) return callback(err);
     if (!marketsInCategory) return callback(null);

--- a/src/server/getters/get-markets-info.ts
+++ b/src/server/getters/get-markets-info.ts
@@ -2,7 +2,7 @@ import { each } from "async";
 import BigNumber from "bignumber.js";
 import * as Knex from "knex";
 import { Address, MarketsRowWithCreationTime, OutcomesRow, UIMarketInfo, UIMarketsInfo, UIOutcomeInfo, ErrorCallback } from "../../types";
-import { reshapeOutcomesRowToUIOutcomeInfo, reshapeMarketsRowToUIMarketInfo, getMarketsWithReportingState } from "./get-market-info";
+import { reshapeOutcomesRowToUIOutcomeInfo, reshapeMarketsRowToUIMarketInfo, getMarketsWithReportingState } from "./database";
 import { queryModifier } from "./database";
 
 export function getMarketsInfo(db: Knex, universe: Address|null|undefined, marketIDs: Array<Address>|null|undefined, sortBy: string|null|undefined, isSortDescending: boolean|null|undefined, limit: number|null|undefined, offset: number|null|undefined, callback: (err: Error|null, result?: UIMarketsInfo) => void): void {

--- a/src/server/getters/get-markets-info.ts
+++ b/src/server/getters/get-markets-info.ts
@@ -3,23 +3,22 @@ import BigNumber from "bignumber.js";
 import * as Knex from "knex";
 import { Address, MarketsRowWithCreationTime, OutcomesRow, UIMarketInfo, UIMarketsInfo, UIOutcomeInfo, ErrorCallback } from "../../types";
 import { reshapeOutcomesRowToUIOutcomeInfo, reshapeMarketsRowToUIMarketInfo, getMarketsWithReportingState } from "./get-market-info";
-import { sortDirection } from "../../utils/sort-direction";
+import { queryModifier } from "./database";
 
 export function getMarketsInfo(db: Knex, universe: Address|null|undefined, marketIDs: Array<Address>|null|undefined, sortBy: string|null|undefined, isSortDescending: boolean|null|undefined, limit: number|null|undefined, offset: number|null|undefined, callback: (err: Error|null, result?: UIMarketsInfo) => void): void {
-  let marketsQuery: Knex.QueryBuilder = getMarketsWithReportingState(db).orderBy("creationTime");
+  let query: Knex.QueryBuilder = getMarketsWithReportingState(db).orderBy("creationTime");
   if (universe == null && marketIDs == null) {
     return callback(new Error("must include universe or marketIDs parameters"));
   }
   if (universe != null) {
-    marketsQuery = marketsQuery.where({ universe });
+    query = query.where({ universe });
   }
   if (marketIDs != null) {
-    marketsQuery = marketsQuery.whereIn("markets.marketID", marketIDs);
+    query = query.whereIn("markets.marketID", marketIDs);
   }
-  marketsQuery = marketsQuery.orderBy(sortBy || "markets.volume", sortDirection(isSortDescending, "desc"));
-  if (limit != null) marketsQuery = marketsQuery.limit(limit);
-  if (offset != null) marketsQuery = marketsQuery.offset(offset);
-  marketsQuery.asCallback((err: Error|null, marketsRows?: Array<MarketsRowWithCreationTime>): void => {
+  query = queryModifier(query, "volume", "desc", sortBy, isSortDescending, limit, offset);
+  console.log(query.toSQL());
+  query.asCallback((err: Error|null, marketsRows?: Array<MarketsRowWithCreationTime>): void => {
     if (err) return callback(err);
     if (!marketsRows || !marketsRows.length) return callback(null);
     const marketsInfo: UIMarketsInfo = [];

--- a/src/server/getters/get-markets-info.ts
+++ b/src/server/getters/get-markets-info.ts
@@ -6,7 +6,7 @@ import { reshapeOutcomesRowToUIOutcomeInfo, reshapeMarketsRowToUIMarketInfo, get
 import { sortDirection } from "../../utils/sort-direction";
 
 export function getMarketsInfo(db: Knex, universe: Address|null|undefined, marketIDs: Array<Address>|null|undefined, sortBy: string|null|undefined, isSortDescending: boolean|null|undefined, limit: number|null|undefined, offset: number|null|undefined, callback: (err: Error|null, result?: UIMarketsInfo) => void): void {
-  let marketsQuery: Knex.QueryBuilder = getMarketsWithReportingState(db).select("blocks.timestamp as creationTime").leftJoin("blocks", "markets.creationBlockNumber", "blocks.blockNumber").orderBy("creationTime");
+  let marketsQuery: Knex.QueryBuilder = getMarketsWithReportingState(db).orderBy("creationTime");
   if (universe == null && marketIDs == null) {
     return callback(new Error("must include universe or marketIDs parameters"));
   }

--- a/src/server/getters/get-reporting-history.ts
+++ b/src/server/getters/get-reporting-history.ts
@@ -1,7 +1,7 @@
 import * as _ from "lodash";
 import * as Knex from "knex";
 import { Address, JoinedReportsMarketsRow, UIReport } from "../../types";
-import { sortDirection } from "../../utils/sort-direction";
+import { queryModifier } from "./database";
 
 interface UIReports {
   [universe: string]: {
@@ -32,9 +32,7 @@ export function getReportingHistory(db: Knex, reporter: Address, marketID: Addre
     "reports.payout6",
     "reports.payout7",
   ]).from("reports").join("markets", "markets.marketID", "reports.marketID").where(queryData);
-  query = query.orderBy(sortBy || "reportID", sortDirection(isSortDescending, "asc"));
-  if (limit != null) query = query.limit(limit);
-  if (offset != null) query = query.offset(offset);
+  query = queryModifier(query, "reportID", "asc", sortBy, isSortDescending, limit, offset);
   query.asCallback((err: Error|null, joinedReportsMarketsRows?: Array<JoinedReportsMarketsRow>): void => {
     if (err) return callback(err);
     if (!joinedReportsMarketsRows || !joinedReportsMarketsRows.length) return callback(null);

--- a/src/server/getters/get-reporting-summary.ts
+++ b/src/server/getters/get-reporting-summary.ts
@@ -4,7 +4,5 @@ import { sortDirection } from "../../utils/sort-direction";
 
 // Look up reporting summary values. Should take reportingWindow (address) as a parameter and the response should include total number of markets up for reporting, total number of markets up for dispute, total number of markets undergoing and/or resolved via each reporting "tier" (automated, limited, full, fork), etc.
 export function getReportingSummary(db: Knex, reportingWindow: Address, sortBy: string|null|undefined, isSortDescending: boolean|null|undefined, limit: number|null|undefined, offset: number|null|undefined, callback: (err: Error|null, result?: any) => void): void {
-  // query = query.orderBy(sortBy || "volume", sortDirection(isSortDescending, "desc"));
-  // if (limit != null) query = query.limit(limit);
-  // if (offset != null) query = query.offset(offset);
+  //   query = queryModifier(query, sortBy || "volume", isSortDescending, limit, offset);
 }

--- a/src/server/getters/get-user-trading-history.ts
+++ b/src/server/getters/get-user-trading-history.ts
@@ -1,6 +1,6 @@
 import * as Knex from "knex";
 import { Address, Bytes32, TradesRow, UITrade } from "../../types";
-import { sortDirection } from "../../utils/sort-direction";
+import { queryModifier } from "./database";
 
 interface TradingHistoryRow extends Partial<TradesRow> {
   timestamp: number;
@@ -24,9 +24,7 @@ export function getUserTradingHistory(db: Knex|Knex.Transaction, account: Addres
   if (marketID != null) query = query.andWhere("trades.marketID", marketID);
   if (outcome != null) query = query.andWhere("trades.outcome", outcome);
   if (orderType != null) query = query.andWhere("trades.orderType", orderType);
-  query = query.orderBy(sortBy || "trades.blockNumber", sortDirection(isSortDescending, "desc"));
-  if (limit != null) query = query.limit(limit);
-  if (offset != null) query = query.offset(offset);
+  query = queryModifier(query,  "trades.blockNumber", "desc", sortBy, isSortDescending, limit, offset);
   query.asCallback((err: Error|null, userTradingHistory?: Array<TradingHistoryRow>): void => {
     if (err) return callback(err);
     if (!userTradingHistory || !userTradingHistory.length) return callback(null);

--- a/src/server/getters/get-user-trading-positions.ts
+++ b/src/server/getters/get-user-trading-positions.ts
@@ -1,14 +1,13 @@
 import * as Knex from "knex";
 import { Address } from "../../types";
 import { sortDirection } from "../../utils/sort-direction";
+import { queryModifier } from "./database";
 
 // Look up a user's current trading positions. Should take account (address) as a required parameter and market and outcome as optional parameters. Response should include the user's position after the trade, in both "raw" and "adjusted-for-user-intention" formats -- the latter meaning that short positions are shown as negative, rather than as positive positions in the other outcomes), and realized and unrealized profit/loss.
 export function getUserTradingPositions(db: Knex, account: Address, marketID: Address|null|undefined, outcome: number|null|undefined, sortBy: string|null|undefined, isSortDescending: boolean|null|undefined, limit: number|null|undefined, offset: number|null|undefined, callback: (err: Error|null, result?: any) => void): void {
   let query = db.select(["marketID", "outcome", "numShares", "numSharesAdjustedForUserIntention", "realizedProfitLoss", "unrealizedProfitLoss"]).from("positions").where({ account });
   if (marketID != null) query = query.andWhere({ marketID });
   if (outcome != null) query = query.andWhere({ outcome });
-  query = query.orderBy(sortBy || "outcome", sortDirection(isSortDescending, "asc"));
-  if (limit != null) query = query.limit(limit);
-  if (offset != null) query = query.offset(offset);
+  query = queryModifier(query, "outcome", "asc", sortBy, isSortDescending, limit, offset);
   query.asCallback(callback);
 }


### PR DESCRIPTION
This is a small change now, but I imagine one of the sorting options we're going to want to have is `creationTime`? (even though technically, `creationBlockNumber` will give same sort order)? And that would mean that join would have to happen in all getters, not just those that return full details. I imagine we'll join more tables and want to start following a similar pattern to prevent the join logic from spreading to every getter.