### PR TITLE
small fixes to getter signatures and behavior

### DIFF
--- a/src/server/dispatch-json-rpc-request.ts
+++ b/src/server/dispatch-json-rpc-request.ts
@@ -32,7 +32,7 @@ export function dispatchJsonRpcRequest(db: Knex, request: JsonRpcRequest, callba
     case "getMarketsCreatedByUser":
       return getMarketsCreatedByUser(db, request.params.universe, request.params.creator, request.params.sortBy, request.params.isSortDescending, request.params.limit, request.params.offset, callback);
     case "getReportingHistory":
-      return getReportingHistory(db, request.params.reporter, request.params.marketID, request.params.universe, request.params.reportingWindow, request.params.sortBy, request.params.isSortDescending, request.params.limit, request.params.offset, callback);
+      return getReportingHistory(db, request.params.reporter, request.params.universe, request.params.marketID, request.params.reportingWindow, request.params.sortBy, request.params.isSortDescending, request.params.limit, request.params.offset, callback);
     case "getMarketsAwaitingDesignatedReporting":
       return getMarketsAwaitingDesignatedReporting(db, request.params.universe, request.params.designatedReporter, request.params.sortBy, request.params.isSortDescending, request.params.limit, request.params.offset, callback);
     case "getMarketsAwaitingReporting":

--- a/src/server/getters/get-markets-created-by-user.ts
+++ b/src/server/getters/get-markets-created-by-user.ts
@@ -4,7 +4,7 @@ import { queryModifier } from "./database";
 
 // Should return the total amount of fees earned so far by the market creator.
 export function getMarketsCreatedByUser(db: Knex, universe: Address, creator: Address, sortBy: string|null|undefined, isSortDescending: boolean|null|undefined, limit: number|null|undefined, offset: number|null|undefined, callback: (err: Error|null, result?: Array<Address>) => void): void {
-  let query = db.select("marketID").from("markets").where({ marketCreator: creator });
+  let query = db.select("marketID").from("markets").where({ marketCreator: creator }).where({ universe });
   query = queryModifier(query, "volume", "desc", sortBy, isSortDescending, limit, offset);
   query.asCallback((err: Error|null, rows?: Array<MarketsContractAddressRow>): void => {
     if (err) return callback(err);

--- a/src/server/getters/get-markets-info.ts
+++ b/src/server/getters/get-markets-info.ts
@@ -9,7 +9,7 @@ interface MarketOutcomeResult {
   outcomesRows: Array<OutcomesRow>;
 }
 
-export function getMarketsInfo(db: Knex, marketIDs: Array<Address>|null|undefined, callback: (err: Error|null, result?: UIMarketsInfo) => void): void {
+export function getMarketsInfo(db: Knex, marketIDs: Array<Address>, callback: (err: Error|null, result?: UIMarketsInfo) => void): void {
   let marketsQuery: Knex.QueryBuilder = getMarketsWithReportingState(db);
   if (marketIDs == null || !marketIDs.length) return callback(new Error("must include marketIDs parameter"));
   marketsQuery = marketsQuery.whereIn("markets.marketID", marketIDs);

--- a/src/server/getters/get-reporting-history.ts
+++ b/src/server/getters/get-reporting-history.ts
@@ -10,7 +10,7 @@ interface UIReports {
 }
 
 // Look up a user's reporting history (i.e., all reports submitted by a given reporter); should take reporter (address) as a required parameter and take market, universe, and reportingWindow all as optional parameters. For reporting windows that are complete, should also include the consensus outcome, whether the user's report matched the consensus, how much REP the user gained or lost from redistribution, and how much the user earned in reporting fees.
-export function getReportingHistory(db: Knex, universe: Address|null, reporter: Address, marketID: Address|null, reportingWindow: Address|null, sortBy: string|null|undefined, isSortDescending: boolean|null|undefined, limit: number|null|undefined, offset: number|null|undefined, callback: (err: Error|null, result?: any) => void): void {
+export function getReportingHistory(db: Knex, reporter: Address, universe: Address|null, marketID: Address|null, reportingWindow: Address|null, sortBy: string|null|undefined, isSortDescending: boolean|null|undefined, limit: number|null|undefined, offset: number|null|undefined, callback: (err: Error|null, result?: any) => void): void {
   // { universe: { marketID: { marketID, reportingWindow, payoutNumerators, isCategorical, isScalar, isIndeterminate } } }
   if (universe == null && marketID == null && reportingWindow == null) return callback(new Error("Must provide reference to universe, specify universe, marketID, reportingWindow"));
   let query = db.select([

--- a/test/server/getters/get-markets-created-by-user.js
+++ b/test/server/getters/get-markets-created-by-user.js
@@ -19,6 +19,7 @@ describe("server/getters/get-markets-created-by-user", () => {
   test({
     description: "user has created 3 markets",
     params: {
+      universe: "0x000000000000000000000000000000000000000b",
       creator: "0x0000000000000000000000000000000000000b0b",
     },
     assertions: (err, marketsCreatedByUser) => {
@@ -33,6 +34,7 @@ describe("server/getters/get-markets-created-by-user", () => {
   test({
     description: "user has created 1 market",
     params: {
+      universe: "0x000000000000000000000000000000000000000b",
       creator: "0x000000000000000000000000000000000000d00d",
     },
     assertions: (err, marketsCreatedByUser) => {
@@ -45,6 +47,7 @@ describe("server/getters/get-markets-created-by-user", () => {
   test({
     description: "user has not created any markets",
     params: {
+      universe: "0x000000000000000000000000000000000000000b",
       creator: "0x0000000000000000000000000000000000000bbb",
     },
     assertions: (err, marketsCreatedByUser) => {

--- a/test/server/getters/get-reporting-history.js
+++ b/test/server/getters/get-reporting-history.js
@@ -9,7 +9,7 @@ describe("server/getters/get-reporting-history", () => {
     it(t.description, (done) => {
       setupTestDb((err, db) => {
         assert.isNull(err);
-        getReportingHistory(db, t.params.universe, t.params.reporter, t.params.marketID, t.params.reportingWindow, t.params.sortBy, t.params.isSortDescending, t.params.limit, t.params.offset, (err, reportingHistory) => {
+        getReportingHistory(db, t.params.reporter, t.params.universe, t.params.marketID, t.params.reportingWindow, t.params.sortBy, t.params.isSortDescending, t.params.limit, t.params.offset, (err, reportingHistory) => {
           t.assertions(err, reportingHistory);
           done();
         });


### PR DESCRIPTION
suggestions from @adrake33 he found while writing some docs.

Required parameters should come first
getMarketsInfo MUST have marketIDs specified (was optional from when it also took a universe)
actually filter by universe in `markets-created-by-user`