### PR TITLE
actually send the error to the websocket client, instead of just logging it

### DIFF
--- a/src/server/getters/get-reporting-history.ts
+++ b/src/server/getters/get-reporting-history.ts
@@ -12,7 +12,7 @@ interface UIReports {
 // Look up a user's reporting history (i.e., all reports submitted by a given reporter); should take reporter (address) as a required parameter and take market, universe, and reportingWindow all as optional parameters. For reporting windows that are complete, should also include the consensus outcome, whether the user's report matched the consensus, how much REP the user gained or lost from redistribution, and how much the user earned in reporting fees.
 export function getReportingHistory(db: Knex, reporter: Address, universe: Address|null, marketID: Address|null, reportingWindow: Address|null, sortBy: string|null|undefined, isSortDescending: boolean|null|undefined, limit: number|null|undefined, offset: number|null|undefined, callback: (err: Error|null, result?: any) => void): void {
   // { universe: { marketID: { marketID, reportingWindow, payoutNumerators, isCategorical, isScalar, isIndeterminate } } }
-  if (universe == null && marketID == null && reportingWindow == null) return callback(new Error("Must provide reference to universe, specify universe, marketID, reportingWindow"));
+  if (universe == null && marketID == null && reportingWindow == null) return callback(new Error("Must provide reference to universe, specify universe, marketID, or reportingWindow"));
   let query = db.select([
     "reports.marketID",
     "markets.universe",

--- a/src/server/run-websocket-server.ts
+++ b/src/server/run-websocket-server.ts
@@ -42,8 +42,12 @@ export function runWebsocketServer(db: Knex, port: number): WebSocket.Server {
           websocket.send(makeJsonRpcResponse(message.id, true));
         } else {
           dispatchJsonRpcRequest(db, message as JsonRpcRequest, (err: Error|null, result?: any): void => {
-            if (err) return console.error("dispatch error: ", err);
-            websocket.send(makeJsonRpcResponse(message.id, result || null));
+            if (err) {
+              console.error("getter error: ", err);
+              websocket.send(makeJsonRpcError(message.id, JsonRpcErrorCode.InvalidParams, err.message, false));
+            } else {
+              websocket.send(makeJsonRpcResponse(message.id, result || null));
+            }
           });
         }
       } catch (exc) {


### PR DESCRIPTION
Aside from being correct, should help a lot for debugging

/cc @stephensprinkle 