### PR TITLE
initial commit of getReportingSummary

### DIFF
--- a/scripts/payloads/getReportingSummary.json
+++ b/scripts/payloads/getReportingSummary.json
@@ -1,0 +1,8 @@
+{
+  "id": 11,
+  "jsonrpc": "2.0",
+  "method": "getReportingSummary",
+  "params": {
+    "reportingWindow": "0x1000000000000000000000000000000000000000"
+  }
+}

--- a/src/server/getters/get-reporting-summary.ts
+++ b/src/server/getters/get-reporting-summary.ts
@@ -1,8 +1,15 @@
 import * as Knex from "knex";
 import { Address } from "../../types";
 import { sortDirection } from "../../utils/sort-direction";
+import { getMarketsWithReportingState } from "./database";
 
 // Look up reporting summary values. Should take reportingWindow (address) as a parameter and the response should include total number of markets up for reporting, total number of markets up for dispute, total number of markets undergoing and/or resolved via each reporting "tier" (automated, limited, full, fork), etc.
 export function getReportingSummary(db: Knex, reportingWindow: Address, callback: (err: Error|null, result?: any) => void): void {
-  //   query = queryModifier(query, sortBy || "volume", isSortDescending, limit, offset);
+    const query = getMarketsWithReportingState(db, []).countDistinct("markets.marketID as count").where({ reportingWindow });
+    query.select("market_state.reportingState").groupBy("market_state.reportingState");
+    query.asCallback((err?: Error|null, summaryRows?: Array<any>): void => {
+      if (err) return callback(err);
+      if (!summaryRows) return callback(null);
+      callback(null, summaryRows.reduce((acc, cur) => {acc[cur.reportingState] = cur.count; return acc; }, {}));
+    });
 }

--- a/src/server/getters/get-reporting-summary.ts
+++ b/src/server/getters/get-reporting-summary.ts
@@ -1,6 +1,5 @@
 import * as Knex from "knex";
 import { Address } from "../../types";
-import { sortDirection } from "../../utils/sort-direction";
 import { getMarketsWithReportingState } from "./database";
 
 // Look up reporting summary values. Should take reportingWindow (address) as a parameter and the response should include total number of markets up for reporting, total number of markets up for dispute, total number of markets undergoing and/or resolved via each reporting "tier" (automated, limited, full, fork), etc.

--- a/test/server/getters/get-reporting-summary.js
+++ b/test/server/getters/get-reporting-summary.js
@@ -1,0 +1,42 @@
+"use strict";
+
+const assert = require("chai").assert;
+const setupTestDb = require("../../test.database");
+const { getReportingSummary } = require("../../../build/server/getters/get-reporting-summary");
+
+describe("server/getters/get-reporting-summary", () => {
+  const test = (t) => {
+    it(t.description, (done) => {
+      setupTestDb((err, db) => {
+        assert.isNull(err);
+        getReportingSummary(db, t.params.reportingWindow, (err, reportingSummary) => {
+          t.assertions(err, reportingSummary);
+          done();
+        });
+      });
+    });
+  };
+  test({
+    description: "get valid reporting window",
+    params: {
+      reportingWindow: "0x1000000000000000000000000000000000000000",
+    },
+    assertions: (err, reportingSummary) => {
+      assert.isNull(err);
+      assert.deepEqual(reportingSummary, {
+        "DESIGNATED_REPORTING": 3,
+        "FIRST_REPORTING": 1,
+      });
+    },
+  });
+  test({
+    description: "non-existent reporting window",
+    params: {
+      reportingWindow: "0xfffffffffffff000000000000000000000000000",
+    },
+    assertions: (err, reportingSummary) => {
+      assert.isNull(err);
+      assert.isDeepEqual(reportingSummary, {});
+    },
+  });
+});

--- a/test/server/getters/get-reporting-summary.js
+++ b/test/server/getters/get-reporting-summary.js
@@ -36,7 +36,7 @@ describe("server/getters/get-reporting-summary", () => {
     },
     assertions: (err, reportingSummary) => {
       assert.isNull(err);
-      assert.isDeepEqual(reportingSummary, {});
+      assert.deepEqual(reportingSummary, {});
     },
   });
 });


### PR DESCRIPTION
@stephensprinkle I wasn't 100% sure what results you wanted here, let me know if i should change it. This is basically just a

`count(*) where reportingWindow = ? group by reportingState`

```
$ node test-client.js payloads/getReportingSummary.json

payloads/getReportingSummary.json
{
  "id": 11,
  "jsonrpc": "2.0",
  "method": "getReportingSummary",
  "params": {
    "reportingWindow": "0x1000000000000000000000000000000000000000"
  }
}

{
  "id": 11,
  "result": {
    "DESIGNATED_REPORTING": 3,
    "FIRST_REPORTING": 1
  },
  "jsonrpc": "2.0",
  "error": null
}
```