### PR TITLE
simple fix for open orders param filtering

### DIFF
--- a/src/server/getters/get-open-orders.ts
+++ b/src/server/getters/get-open-orders.ts
@@ -40,7 +40,7 @@ export function getOpenOrders(db: Knex, universe: Address|null, marketID: Addres
     outcome,
     orderType,
     orderCreator: creator,
-  }, _.isNull);
+  }, _.isNil);
   let query: Knex.QueryBuilder = db.select(["orders.*", `blocks.timestamp as creationTime`]).from("orders").leftJoin("blocks", "orders.creationBlockNumber", "blocks.blockNumber").where(queryData).whereNull("isRemoved");
   query = queryModifier(query, "volume", "desc", sortBy, isSortDescending, limit, offset);
   query.asCallback((err: Error|null, ordersRows?: Array<OrdersRowWithCreationTime>): void => {


### PR DESCRIPTION
So we really need to resolve the issue of typescript types being way too loose and not actually ensuring that something that is.

`Address|null`

is not actually `undefined`

This is the third time it has burned us.

