### PR TITLE
add earliest and latest CreationTime filter to get-orders, add test

### DIFF
--- a/scripts/payloads/getOrders-earliestCreationTime.json
+++ b/scripts/payloads/getOrders-earliestCreationTime.json
@@ -1,0 +1,13 @@
+{
+  "id": 3,
+  "jsonrpc": "2.0",
+  "method": "getOpenOrders",
+  "params": {
+    "marketID": "0x0000000000000000000000000000000000000001",
+    "outcome": null,
+    "orderType": "buy",
+    "creator": null,
+    "orderState": "OPEN",
+    "earliestCreationTime": 1506473501
+  }
+}

--- a/src/server/dispatch-json-rpc-request.ts
+++ b/src/server/dispatch-json-rpc-request.ts
@@ -57,7 +57,7 @@ export function dispatchJsonRpcRequest(db: Knex, request: JsonRpcRequest, callba
     case "getMarketsInfo":
       return getMarketsInfo(db, request.params.marketIDs, callback);
     case "getOpenOrders":
-      return getOrders(db, request.params.universe, request.params.marketID, request.params.outcome, request.params.orderType, request.params.creator, request.params.orderState, request.params.sortBy, request.params.isSortDescending, request.params.limit, request.params.offset, callback);
+      return getOrders(db, request.params.universe, request.params.marketID, request.params.outcome, request.params.orderType, request.params.creator, request.params.orderState, request.params.earliestCreationTime, request.params.latestCreationTime, request.params.sortBy, request.params.isSortDescending, request.params.limit, request.params.offset, callback);
     default:
       callback(new Error("unknown json rpc method"));
   }

--- a/src/server/getters/get-orders.ts
+++ b/src/server/getters/get-orders.ts
@@ -18,7 +18,7 @@ interface OrdersRowWithCreationTime extends OrdersRow {
 }
 
 // market, outcome, creator, orderType, limit, sort
-export function getOrders(db: Knex, universe: Address|null, marketID: Address|null, outcome: number|null, orderType: string|null, creator: Address|null, orderState: OrderState|null, sortBy: string|null|undefined, isSortDescending: boolean|null|undefined, limit: number|null|undefined, offset: number|null|undefined, callback: (err: Error|null, result?: any) => void): void {
+export function getOrders(db: Knex, universe: Address|null, marketID: Address|null, outcome: number|null, orderType: string|null, creator: Address|null, orderState: OrderState|null, earliestCreationTime: number|null, latestCreationTime: number|null, sortBy: string|null|undefined, isSortDescending: boolean|null|undefined, limit: number|null|undefined, offset: number|null|undefined, callback: (err: Error|null, result?: any) => void): void {
   if (universe == null && marketID == null) return callback(new Error("Must provide universe, either via universe or marketID"));
   const queryData: {} = _.omitBy({
     universe,
@@ -31,6 +31,8 @@ export function getOrders(db: Knex, universe: Address|null, marketID: Address|nu
   query.leftJoin("blocks", "orders.blockNumber", "blocks.blockNumber");
   query.leftJoin("markets", "orders.marketID", "markets.marketID");
   query.where(queryData);
+  if (earliestCreationTime != null) query.where("creationTime", ">", earliestCreationTime);
+  if (latestCreationTime != null) query.where("creationTime", "<", latestCreationTime);
   if ( orderState != null && orderState !== OrderState.ALL) query.where("orderState", orderState);
   queryModifier(query, "volume", "desc", sortBy, isSortDescending, limit, offset);
   query.asCallback((err: Error|null, ordersRows?: Array<OrdersRowWithCreationTime>): void => {

--- a/src/server/getters/get-orders.ts
+++ b/src/server/getters/get-orders.ts
@@ -31,8 +31,8 @@ export function getOrders(db: Knex, universe: Address|null, marketID: Address|nu
   query.leftJoin("blocks", "orders.blockNumber", "blocks.blockNumber");
   query.leftJoin("markets", "orders.marketID", "markets.marketID");
   query.where(queryData);
-  if (earliestCreationTime != null) query.where("creationTime", ">", earliestCreationTime);
-  if (latestCreationTime != null) query.where("creationTime", "<", latestCreationTime);
+  if (earliestCreationTime != null) query.where("creationTime", ">=", earliestCreationTime);
+  if (latestCreationTime != null) query.where("creationTime", "<=", latestCreationTime);
   if ( orderState != null && orderState !== OrderState.ALL) query.where("orderState", orderState);
   queryModifier(query, "volume", "desc", sortBy, isSortDescending, limit, offset);
   query.asCallback((err: Error|null, ordersRows?: Array<OrdersRowWithCreationTime>): void => {

--- a/src/server/getters/get-stake-tokens.ts
+++ b/src/server/getters/get-stake-tokens.ts
@@ -22,5 +22,4 @@ export function getStakeTokens(db: Knex, universe: Address, account: Address, st
       if (err) return callback(err);
       callback(null, stakeTokens.reduce((acc: UIStakeTokens, cur) => {acc[cur.stakeToken] = reshapeStakeTokensRowToUIStakeTokenInfo(cur); return acc; }, {}));
     });
-
 }

--- a/test/server/getters/get-orders.js
+++ b/test/server/getters/get-orders.js
@@ -9,7 +9,7 @@ describe("server/getters/get-orders", () => {
     it(t.description, (done) => {
       setupTestDb((err, db) => {
         assert.isNull(err);
-        getOrders(db, t.params.universe, t.params.marketID, t.params.outcome, t.params.orderType, t.params.creator, t.params.orderState, t.params.sortBy, t.params.isSortDescending, t.params.limit, t.params.offset, (err, openOrders) => {
+        getOrders(db, t.params.universe, t.params.marketID, t.params.outcome, t.params.orderType, t.params.creator, t.params.orderState, t.params.earliestCreationTime, t.params.latestCreationTime, t.params.sortBy, t.params.isSortDescending, t.params.limit, t.params.offset, (err, openOrders) => {
           t.assertions(err, openOrders);
           done();
         });
@@ -261,6 +261,85 @@ describe("server/getters/get-orders", () => {
             },
           },
         },
+        "0x0000000000000000000000000000000000000003": {
+          1: {
+            sell: {
+              "0x8000000000000000000000000000000000000000000000000000000000000000": {
+                amount: 2,
+                creationBlockNumber: 1400002,
+                creationTime: 1506473515,
+                transactionHash: "0x0000000000000000000000000000000000000000000000000000000000000A09",
+                transactionIndex: 0,
+                fullPrecisionAmount: 2,
+                fullPrecisionPrice: 0.6,
+                orderState: "OPEN",
+                owner: "0x0000000000000000000000000000000000000b0b",
+                price: 0.6,
+                shareToken: "0x2000000000000000000000000000000000000000",
+                sharesEscrowed: 0,
+                tokensEscrowed: 1.2,
+              },
+            },
+          },
+        },
+        "0x0000000000000000000000000000000000000011": {
+          1: {
+            buy: {
+              "0x7000000000000000000000000000000000000000000000000000000000000000": {
+                amount: 2,
+                creationBlockNumber: 1400002,
+                creationTime: 1506473515,
+                transactionHash: "0x0000000000000000000000000000000000000000000000000000000000000A08",
+                transactionIndex: 0,
+                fullPrecisionAmount: 2.0000001,
+                fullPrecisionPrice: 0.6,
+                orderState: "OPEN",
+                owner: "0x0000000000000000000000000000000000000b0b",
+                price: 0.6,
+                shareToken: "0x2000000000000000000000000000000000000000",
+                sharesEscrowed: 0,
+                tokensEscrowed: 1.20000006,
+              },
+            },
+          },
+        },
+        "0x0000000000000000000000000000000000000018": {
+          0: {
+            buy: {
+              "0x6000000000000000000000000000000000000000000000000000000000000000": {
+                amount: 2,
+                creationBlockNumber: 1400002,
+                creationTime: 1506473515,
+                transactionHash: "0x0000000000000000000000000000000000000000000000000000000000000A07",
+                transactionIndex: 0,
+                fullPrecisionAmount: 2,
+                fullPrecisionPrice: 0.600001,
+                orderState: "OPEN",
+                owner: "0x0000000000000000000000000000000000000b0b",
+                price: 0.6,
+                shareToken: "0x1000000000000000000000000000000000000000",
+                sharesEscrowed: 0,
+                tokensEscrowed: 1.200002,
+              },
+            },
+          },
+        },
+      });
+    },
+  });
+  test({
+    description: "get orders created by user b0b DATE",
+    params: {
+      universe: "0x000000000000000000000000000000000000000b",
+      marketID: null,
+      outcome: null,
+      orderType: null,
+      creator: "0x0000000000000000000000000000000000000b0b",
+      earliestCreationTime: 1506473501,
+    },
+    assertions: (err, openOrders) => {
+      assert.isNull(err);
+      assert.deepEqual(openOrders, {
         "0x0000000000000000000000000000000000000003": {
           1: {
             sell: {

--- a/test/server/getters/get-orders.js
+++ b/test/server/getters/get-orders.js
@@ -328,7 +328,7 @@ describe("server/getters/get-orders", () => {
     },
   });
   test({
-    description: "get orders created by user b0b DATE",
+    description: "get orders created by user b0b filtered by date",
     params: {
       universe: "0x000000000000000000000000000000000000000b",
       marketID: null,
@@ -336,6 +336,7 @@ describe("server/getters/get-orders", () => {
       orderType: null,
       creator: "0x0000000000000000000000000000000000000b0b",
       earliestCreationTime: 1506473501,
+      latestCreationTime: 1506473515,
     },
     assertions: (err, openOrders) => {
       assert.isNull(err);


### PR DESCRIPTION
@bthaile here's what we discussed, applied to getOrders

Without time filter:
```
$ node ../test-client.js getOrders-open.json

getOrders-open.json
{
  "id": 3,
  "jsonrpc": "2.0",
  "method": "getOpenOrders",
  "params": {
    "marketID": "0x0000000000000000000000000000000000000001",
    "outcome": null,
    "orderType": "buy",
    "creator": null,
    "orderState": "OPEN"
  }
}

{
  "id": 3,
  "result": {
    "0x0000000000000000000000000000000000000001": {
      "0": {
        "buy": {
          "0x1000000000000000000000000000000000000000000000000000000000000000": {
            "creationBlockNumber": 1400001,
            "transactionHash": "0x0000000000000000000000000000000000000000000000000000000000000A00",
            "transactionIndex": 0,
            "shareToken": "0x1000000000000000000000000000000000000000",
            "owner": "0x0000000000000000000000000000000000000b0b",
            "creationTime": 1506473500,
            "orderState": "OPEN",
            "price": 0.7,
            "amount": 1,
            "fullPrecisionPrice": 0.7,
            "fullPrecisionAmount": 1,
            "tokensEscrowed": 0.7,
            "sharesEscrowed": 0
          },
          "0x2000000000000000000000000000000000000000000000000000000000000000": {
            "creationBlockNumber": 1400002,
            "transactionHash": "0x0000000000000000000000000000000000000000000000000000000000000A01",
            "transactionIndex": 0,
            "shareToken": "0x1000000000000000000000000000000000000000",
            "owner": "0x000000000000000000000000000000000000d00d",
            "creationTime": 1506473515,
            "orderState": "OPEN",
            "price": 0.6,
            "amount": 2,
            "fullPrecisionPrice": 0.600001,
            "fullPrecisionAmount": 2,
            "tokensEscrowed": 1.200002,
            "sharesEscrowed": 0
          },
          "0x5000000000000000000000000000000000000000000000000000000000000000": {
            "creationBlockNumber": 1400001,
            "transactionHash": "0x0000000000000000000000000000000000000000000000000000000000000A06",
            "transactionIndex": 0,
            "shareToken": "0x1000000000000000000000000000000000000000",
            "owner": "0x0000000000000000000000000000000000000b0b",
            "creationTime": 1506473500,
            "orderState": "OPEN",
            "price": 0.7,
            "amount": 1,
            "fullPrecisionPrice": 0.7,
            "fullPrecisionAmount": 1,
            "tokensEscrowed": 0.7,
            "sharesEscrowed": 0
          }
        }
      },
      "1": {
        "buy": {
          "0x3000000000000000000000000000000000000000000000000000000000000000": {
            "creationBlockNumber": 1400002,
            "transactionHash": "0x0000000000000000000000000000000000000000000000000000000000000A02",
            "transactionIndex": 0,
            "shareToken": "0x2000000000000000000000000000000000000000",
            "owner": "0x000000000000000000000000000000000000d00d",
            "creationTime": 1506473515,
            "orderState": "OPEN",
            "price": 0.6,
            "amount": 2,
            "fullPrecisionPrice": 0.6,
            "fullPrecisionAmount": 2.0000001,
            "tokensEscrowed": 1.20000006,
            "sharesEscrowed": 0
          }
        }
      }
    }
  },
  "jsonrpc": "2.0"
}
myna:payloads epheph$ node ../test-client.js getOrders-earliestCreationTime.json

getOrders-earliestCreationTime.json
{
  "id": 3,
  "jsonrpc": "2.0",
  "method": "getOpenOrders",
  "params": {
    "marketID": "0x0000000000000000000000000000000000000001",
    "outcome": null,
    "orderType": "buy",
    "creator": null,
    "orderState": "OPEN",
    "earliestCreationTime": 1506473501
  }
}
```

With time filter (exact same request object otherwise):

```
{
  "id": 3,
  "result": {
    "0x0000000000000000000000000000000000000001": {
      "0": {
        "buy": {
          "0x2000000000000000000000000000000000000000000000000000000000000000": {
            "creationBlockNumber": 1400002,
            "transactionHash": "0x0000000000000000000000000000000000000000000000000000000000000A01",
            "transactionIndex": 0,
            "shareToken": "0x1000000000000000000000000000000000000000",
            "owner": "0x000000000000000000000000000000000000d00d",
            "creationTime": 1506473515,
            "orderState": "OPEN",
            "price": 0.6,
            "amount": 2,
            "fullPrecisionPrice": 0.600001,
            "fullPrecisionAmount": 2,
            "tokensEscrowed": 1.200002,
            "sharesEscrowed": 0
          }
        }
      },
      "1": {
        "buy": {
          "0x3000000000000000000000000000000000000000000000000000000000000000": {
            "creationBlockNumber": 1400002,
            "transactionHash": "0x0000000000000000000000000000000000000000000000000000000000000A02",
            "transactionIndex": 0,
            "shareToken": "0x2000000000000000000000000000000000000000",
            "owner": "0x000000000000000000000000000000000000d00d",
            "creationTime": 1506473515,
            "orderState": "OPEN",
            "price": 0.6,
            "amount": 2,
            "fullPrecisionPrice": 0.6,
            "fullPrecisionAmount": 2.0000001,
            "tokensEscrowed": 1.20000006,
            "sharesEscrowed": 0
          }
        }
      }
    }
  },
  "jsonrpc": "2.0"
}
```