### PR TITLE
Prevents errors in the processLog

### DIFF
--- a/src/blockchain/download-augur-logs.ts
+++ b/src/blockchain/download-augur-logs.ts
@@ -24,7 +24,7 @@ export function downloadAugurLogs(db: Knex, augur: Augur, fromBlock: number, toB
                 nextEventName();
               }
             });
-          })
+          });
         }
       }, nextContractName)
     ), callback);

--- a/src/blockchain/download-augur-logs.ts
+++ b/src/blockchain/download-augur-logs.ts
@@ -10,19 +10,23 @@ export function downloadAugurLogs(db: Knex, augur: Augur, fromBlock: number, toB
   augur.events.getAllAugurLogs({ fromBlock, toBlock }, (err?: string|object|null, allAugurLogs?: AugurLogs): void => {
     if (err) return callback(err instanceof Error ? err : new Error(JSON.stringify(err)));
     eachSeries(Object.keys(allAugurLogs!), (contractName: string, nextContractName: ErrorCallback) => (
-      eachSeries(Object.keys(allAugurLogs![contractName]!), (eventName: string, nextEventName: ErrorCallback) => (
-        db.transaction((trx: Knex.Transaction): void => {
-          processLogs(db, augur, trx, allAugurLogs![contractName]![eventName]!, logProcessors[contractName][eventName], (err?: Error|null): void => {
-            if (err) {
-              trx.rollback();
-              nextEventName(err);
-            } else {
-              trx.commit();
-              nextEventName();
-            }
-          });
-        })
-      ), nextContractName)
+      eachSeries(Object.keys(allAugurLogs![contractName]!), (eventName: string, nextEventName: ErrorCallback) => {
+        if (logProcessors[contractName][eventName] == null) {
+          console.log("Log processor does not exist:", contractName, eventName);
+        } else {
+          db.transaction((trx: Knex.Transaction): void => {
+            processLogs(db, augur, trx, allAugurLogs![contractName]![eventName]!, logProcessors[contractName][eventName], (err?: Error|null): void => {
+              if (err) {
+                trx.rollback();
+                nextEventName(err);
+              } else {
+                trx.commit();
+                nextEventName();
+              }
+            });
+          })
+        }
+      }, nextContractName)
     ), callback);
   });
 }


### PR DESCRIPTION
@adrake33 this was causing the issue.

LegacyRepToken.Mint is not defined, and we fall into the parseLog anyway and look for a '.add' member of undefined

/cc @pgebheim since you were on the call, too, when i was mentioning '.add' exceptions