### PR TITLE
add token names, marketID, and outcome to transfer history

### DIFF
--- a/src/server/getters/get-account-transfer-history.ts
+++ b/src/server/getters/get-account-transfer-history.ts
@@ -12,6 +12,9 @@ export interface TransferRow {
   recipient: Address;
   token: Address;
   value: number;
+  symbol: string|null;
+  outcome: number|null;
+  marketID: Address|null;
 }
 
 export function getAccountTransferHistory(db: Knex, account: Address, token: Address|null|undefined, earliestCreationTime: number|null, latestCreationTime: number|null, sortBy: string|null|undefined, isSortDescending: boolean|null|undefined, limit: number|null|undefined, offset: number|null|undefined, callback: (err: Error|null, transferHistory?: Array<TransferRow>) => void): void {
@@ -25,8 +28,12 @@ export function getAccountTransferHistory(db: Knex, account: Address, token: Add
     "transfers.value",
     "blocks.timestamp as creationTime",
     "blocks.blockHash",
+    "tokens.symbol",
+    "tokens.outcome",
+    "tokens.marketID",
   ]).where((db: Knex): Knex.QueryBuilder => db.where("sender", account).orWhere("recipient", account));
   query.join("blocks", "blocks.blockNumber", "transfers.blockNumber" );
+  query.join("tokens", "tokens.contractAddress", "transfers.token");
   if (token != null) query.andWhere({ token });
   if (earliestCreationTime != null) query.where("creationTime", ">=", earliestCreationTime);
   if (latestCreationTime != null) query.where("creationTime", "<=", latestCreationTime);

--- a/test/server/getters/get-account-transfer-history.js
+++ b/test/server/getters/get-account-transfer-history.js
@@ -35,6 +35,9 @@ describe("server/getters/get-account-transfer-history", () => {
         recipient: "0x000000000000000000000000000000000000d00d",
         token: "0x1000000000000000000000000000000000000000",
         value: 10,
+        symbol: "shares",
+        marketID: "0x0000000000000000000000000000000000000001",
+        outcome: 0,
       }, {
         transactionHash: "0x00000000000000000000000000000000000000000000000000000000d3adb33f",
         logIndex: 0,
@@ -45,6 +48,9 @@ describe("server/getters/get-account-transfer-history", () => {
         recipient: "0x0000000000000000000000000000000000000b0b",
         token: "0x1000000000000000000000000000000000000000",
         value: 2,
+        symbol: "shares",
+        marketID: "0x0000000000000000000000000000000000000001",
+        outcome: 0,
       }, {
         transactionHash: "0x00000000000000000000000000000000000000000000000000000000deadb33f",
         logIndex: 1,
@@ -55,6 +61,9 @@ describe("server/getters/get-account-transfer-history", () => {
         recipient: "0x000000000000000000000000000000000000d00d",
         token: "0x7a305d9b681fb164dc5ad628b5992177dc66aec8",
         value: 47,
+        symbol: "REP",
+        marketID: null,
+        outcome: null,
       }]);
     },
   });
@@ -79,6 +88,9 @@ describe("server/getters/get-account-transfer-history", () => {
         recipient: "0x000000000000000000000000000000000000d00d",
         token: "0x1000000000000000000000000000000000000000",
         value: 10,
+        symbol: "shares",
+        marketID: "0x0000000000000000000000000000000000000001",
+        outcome: 0,
       }]);
     },
   });
@@ -101,6 +113,9 @@ describe("server/getters/get-account-transfer-history", () => {
         recipient: "0x000000000000000000000000000000000000d00d",
         token: "0x7a305d9b681fb164dc5ad628b5992177dc66aec8",
         value: 47,
+        symbol: "REP",
+        marketID: null,
+        outcome: null,
       }]);
     },
   });


### PR DESCRIPTION
```
$ node test-client.js payloads/getAccountTransferHistory-latestCreationTime.json

payloads/getAccountTransferHistory-latestCreationTime.json
{
  "id": 2,
  "jsonrpc": "2.0",
  "method": "getAccountTransferHistory",
  "params": {
    "universe": "0x000000000000000000000000000000000000000b",
    "account": "0x0000000000000000000000000000000000000b0b",
    "token": null,
    "latestCreationTime": 1506473475
  }
}

{
  "id": 2,
  "result": [
    {
      "transactionHash": "0x00000000000000000000000000000000000000000000000000000000deadbeef",
      "logIndex": 0,
      "creationBlockNumber": 1400000,
      "sender": "0x0000000000000000000000000000000000000b0b",
      "recipient": "0x000000000000000000000000000000000000d00d",
      "token": "0x1000000000000000000000000000000000000000",
      "value": 10,
      "creationTime": 1506473474,
      "blockHash": "0x1400000",
      "symbol": "shares",
      "outcome": 0,
      "marketID": "0x0000000000000000000000000000000000000001"
    }
  ],
  "jsonrpc": "2.0"
}
```