### PR TITLE
first pass at downloading blocks when using getAllAugurLogs

### DIFF
--- a/src/blockchain/download-augur-logs.ts
+++ b/src/blockchain/download-augur-logs.ts
@@ -4,11 +4,14 @@ import * as Knex from "knex";
 import { ErrorCallback, FormattedEventLog } from "../types";
 import { processLog } from "./process-logs";
 import { logProcessors } from "./log-processors";
+import { processBlockByNumber } from "./process-block";
 
 export function downloadAugurLogs(db: Knex, augur: Augur, fromBlock: number, toBlock: number, callback: ErrorCallback): void {
   console.log("Getting Augur logs from block " + fromBlock + " to block " + toBlock);
   augur.events.getAllAugurLogs({ fromBlock, toBlock }, (err?: string|object|null, allAugurLogs?: Array<FormattedEventLog>): void => {
     if (err) return callback(err instanceof Error ? err : new Error(JSON.stringify(err)));
+    const blockNumbers = allAugurLogs!.reduce( (set, log) => set.add(log.blockNumber), new Set<number>() );
+    blockNumbers.forEach( (blockNumber: number): void => processBlockByNumber(db, augur, blockNumber));
     eachSeries(allAugurLogs!, (log: FormattedEventLog, nextLog: ErrorCallback) => {
       const contractName = log.contractName;
       const eventName = log.eventName;

--- a/src/blockchain/process-block.ts
+++ b/src/blockchain/process-block.ts
@@ -30,6 +30,12 @@ export function processBlock(db: Knex, augur: Augur, block: Block): void {
   });
 }
 
+export function processBlockByNumber(db: Knex, augur: Augur, blockNumber: number): void {
+  augur.rpc.eth.getBlockByNumber([blockNumber, false], (block: Block): void => {
+    processBlock(db, augur, block);
+  });
+}
+
 export function processBlockRemoval(db: Knex, block: Block): void {
   const blockNumber = parseInt(block.number, 16);
   console.log("block removed:", blockNumber);


### PR DESCRIPTION
@tinybike thoughts about correct behavior when processing block fails? there were no existing callbacks in processBlock, so I didn't add it in this PR, but it's probably correct to add it.

I'm doing the whole thing as 1 pass at the beginning to ease de-duplication of blockNumbers without adding extra logic instead of the nested `eachSeries`