### PR TITLE
Add Docker support to Augur Node

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:8 as builder
 
-WORKDIR /root/
+WORKDIR /app/
 COPY config.json config.json
 COPY tsconfig.json tsconfig.json
 
@@ -9,18 +9,19 @@ RUN npm install
 
 COPY src src
 RUN npm run build
+RUN npm pack
 
 COPY knexfile.js knexfile.js
 RUN npm run migrate
 
 FROM node:8
 EXPOSE 9001
-WORKDIR /root/
-COPY --from=builder /root/build build
-COPY --from=builder /root/node_modules node_modules
+WORKDIR /app/
+COPY --from=builder /app/node_modules node_modules
 
-COPY --from=builder /root/augur.db augur.db
-COPY --from=builder /root/config.json config.json
-COPY --from=builder /root/package.json package.json
+COPY --from=builder /app/augur-node*.tgz /app
+RUN tar xzf augur-node*.tgz && mv package/* . && rm -rf package
+
+COPY --from=builder /app/augur.db augur.db
 
 ENTRYPOINT ["npm", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,11 @@ FROM node:8 as builder
 WORKDIR /root/
 COPY config.json config.json
 COPY tsconfig.json tsconfig.json
-COPY package.json package.json
-COPY src src
 
+COPY package.json package.json
 RUN npm install
+
+COPY src src
 RUN npm run build
 
 COPY knexfile.js knexfile.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:8
+
+EXPOSE 9001
+
+COPY config.json /root/augur-node/config.json
+COPY tsconfig.json /root/augur-node/tsconfig.json
+COPY package.json /root/augur-node/package.json
+COPY src /root/augur-node/src
+
+WORKDIR /root/augur-node
+RUN npm install
+RUN npm run build
+
+ENTRYPOINT ["npm", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,5 @@
+version: '3'
+services:
+  augur-node:
+    build: .
+    image: augurproject/augur-node:dev


### PR DESCRIPTION
Included is a Docker file which exposes the RPC port (9001) and a docker-compose file which can be used to build and name this image with a :dev tag for convenience.