### PR TITLE
simple addition of averagePrice to position

### DIFF
--- a/src/migrations/20171022160433_positions.ts
+++ b/src/migrations/20171022160433_positions.ts
@@ -11,6 +11,7 @@ exports.up = async (knex: Knex): Promise<any> => {
       table.specificType("numSharesAdjustedForUserIntention", "NUMERIC").defaultTo(0).nullable();
       table.specificType("realizedProfitLoss", "NUMERIC").defaultTo(0).nullable();
       table.specificType("unrealizedProfitLoss", "NUMERIC").defaultTo(0).nullable();
+      table.specificType("averagePrice", "NUMERIC").defaultTo(0).nullable();
       table.timestamp("lastUpdated").defaultTo(knex.fn.now()).notNullable();
     });
   });

--- a/src/server/getters/get-user-trading-positions.ts
+++ b/src/server/getters/get-user-trading-positions.ts
@@ -7,7 +7,7 @@ import { queryModifier } from "./database";
 export function getUserTradingPositions(db: Knex, universe: Address|null, account: Address, marketID: Address|null|undefined, outcome: number|null|undefined, sortBy: string|null|undefined, isSortDescending: boolean|null|undefined, limit: number|null|undefined, offset: number|null|undefined, callback: (err: Error|null, result?: any) => void): void {
   if (universe == null && marketID == null ) return callback(new Error("Must provide reference to universe, specify universe or marketID"));
   if (account == null) return callback(new Error("Missing required parameter: account"));
-  const query = db.select(["positions.marketID", "outcome", "numShares", "numSharesAdjustedForUserIntention", "realizedProfitLoss", "unrealizedProfitLoss"]).from("positions").where({ account });
+  const query = db.select(["positions.marketID", "outcome", "averagePrice", "numShares", "numSharesAdjustedForUserIntention", "realizedProfitLoss", "unrealizedProfitLoss"]).from("positions").where({ account });
   if (universe != null) query.join("markets", "markets.marketID", "positions.marketID" ).where({ universe });
   if (marketID != null) query.where({ marketID });
   if (outcome != null) query.where({ outcome });

--- a/test/blockchain/log-processors/order-filled/index.js
+++ b/test/blockchain/log-processors/order-filled/index.js
@@ -179,6 +179,7 @@ describe("blockchain/log-processors/order-filled", () => {
           numSharesAdjustedForUserIntention: 2,
           realizedProfitLoss: 0,
           unrealizedProfitLoss: 0,
+          averagePrice: 0,
           lastUpdated: records.positions[0].lastUpdated,
         }, {
           positionID: 18,
@@ -189,6 +190,7 @@ describe("blockchain/log-processors/order-filled", () => {
           numSharesAdjustedForUserIntention: 0,
           realizedProfitLoss: 0,
           unrealizedProfitLoss: 0,
+          averagePrice: 0,
           lastUpdated: records.positions[0].lastUpdated,
         }, {
           positionID: 19,
@@ -199,6 +201,7 @@ describe("blockchain/log-processors/order-filled", () => {
           numSharesAdjustedForUserIntention: 0,
           realizedProfitLoss: 0,
           unrealizedProfitLoss: 0,
+          averagePrice: 0,
           lastUpdated: records.positions[0].lastUpdated,
         }, {
           positionID: 20,
@@ -209,6 +212,7 @@ describe("blockchain/log-processors/order-filled", () => {
           numSharesAdjustedForUserIntention: 0,
           realizedProfitLoss: 0,
           unrealizedProfitLoss: 0,
+          averagePrice: 0,
           lastUpdated: records.positions[0].lastUpdated,
         }, {
           positionID: 21,
@@ -219,6 +223,7 @@ describe("blockchain/log-processors/order-filled", () => {
           numSharesAdjustedForUserIntention: 0,
           realizedProfitLoss: 0,
           unrealizedProfitLoss: 0,
+          averagePrice: 0,
           lastUpdated: records.positions[0].lastUpdated,
         }, {
           positionID: 22,
@@ -229,6 +234,7 @@ describe("blockchain/log-processors/order-filled", () => {
           numSharesAdjustedForUserIntention: 0,
           realizedProfitLoss: 0,
           unrealizedProfitLoss: 0,
+          averagePrice: 0,
           lastUpdated: records.positions[0].lastUpdated,
         }, {
           positionID: 23,
@@ -239,6 +245,7 @@ describe("blockchain/log-processors/order-filled", () => {
           numSharesAdjustedForUserIntention: 0,
           realizedProfitLoss: 0,
           unrealizedProfitLoss: 0,
+          averagePrice: 0,
           lastUpdated: records.positions[0].lastUpdated,
         }, {
           positionID: 24,
@@ -249,6 +256,7 @@ describe("blockchain/log-processors/order-filled", () => {
           numSharesAdjustedForUserIntention: 0,
           realizedProfitLoss: 0,
           unrealizedProfitLoss: 0,
+          averagePrice: 0,
           lastUpdated: records.positions[0].lastUpdated,
         }]);
       },
@@ -301,6 +309,7 @@ describe("blockchain/log-processors/order-filled", () => {
           numSharesAdjustedForUserIntention: 0,
           realizedProfitLoss: 0,
           unrealizedProfitLoss: 0,
+          averagePrice: 0,
           lastUpdated: records.positions[0].lastUpdated,
         }, {
           positionID: 18,
@@ -311,6 +320,7 @@ describe("blockchain/log-processors/order-filled", () => {
           numSharesAdjustedForUserIntention: 0,
           realizedProfitLoss: 0,
           unrealizedProfitLoss: 0,
+          averagePrice: 0,
           lastUpdated: records.positions[0].lastUpdated,
         }, {
           positionID: 19,
@@ -321,6 +331,7 @@ describe("blockchain/log-processors/order-filled", () => {
           numSharesAdjustedForUserIntention: 0,
           realizedProfitLoss: 0,
           unrealizedProfitLoss: 0,
+          averagePrice: 0,
           lastUpdated: records.positions[0].lastUpdated,
         }, {
           positionID: 20,
@@ -331,6 +342,7 @@ describe("blockchain/log-processors/order-filled", () => {
           numSharesAdjustedForUserIntention: 0,
           realizedProfitLoss: 0,
           unrealizedProfitLoss: 0,
+          averagePrice: 0,
           lastUpdated: records.positions[0].lastUpdated,
         }, {
           positionID: 21,
@@ -341,6 +353,7 @@ describe("blockchain/log-processors/order-filled", () => {
           numSharesAdjustedForUserIntention: 0,
           realizedProfitLoss: 0,
           unrealizedProfitLoss: 0,
+          averagePrice: 0,
           lastUpdated: records.positions[0].lastUpdated,
         }, {
           positionID: 22,
@@ -351,6 +364,7 @@ describe("blockchain/log-processors/order-filled", () => {
           numSharesAdjustedForUserIntention: 0,
           realizedProfitLoss: 0,
           unrealizedProfitLoss: 0,
+          averagePrice: 0,
           lastUpdated: records.positions[0].lastUpdated,
         }, {
           positionID: 23,
@@ -361,6 +375,7 @@ describe("blockchain/log-processors/order-filled", () => {
           numSharesAdjustedForUserIntention: 0,
           realizedProfitLoss: 0,
           unrealizedProfitLoss: 0,
+          averagePrice: 0,
           lastUpdated: records.positions[0].lastUpdated,
         }, {
           positionID: 24,
@@ -371,6 +386,7 @@ describe("blockchain/log-processors/order-filled", () => {
           numSharesAdjustedForUserIntention: 0,
           realizedProfitLoss: 0,
           unrealizedProfitLoss: 0,
+          averagePrice: 0,
           lastUpdated: records.positions[0].lastUpdated,
         }]);
       },

--- a/test/server/getters/get-user-trading-positions.js
+++ b/test/server/getters/get-user-trading-positions.js
@@ -37,6 +37,7 @@ describe("server/getters/get-user-trading-positions", () => {
         "numSharesAdjustedForUserIntention": 0.2,
         "realizedProfitLoss": 0,
         "unrealizedProfitLoss": 11,
+        "averagePrice": 0,
       }, {
         "marketID": "0x0000000000000000000000000000000000000001",
         "outcome": 1,
@@ -44,6 +45,7 @@ describe("server/getters/get-user-trading-positions", () => {
         "numSharesAdjustedForUserIntention": 0,
         "realizedProfitLoss": 0,
         "unrealizedProfitLoss": 0,
+        "averagePrice": 0,
       }, {
         "marketID": "0x0000000000000000000000000000000000000001",
         "outcome": 2,
@@ -51,6 +53,7 @@ describe("server/getters/get-user-trading-positions", () => {
         "numSharesAdjustedForUserIntention": 0,
         "realizedProfitLoss": 0,
         "unrealizedProfitLoss": 0,
+        "averagePrice": 0,
       }, {
         "marketID": "0x0000000000000000000000000000000000000001",
         "outcome": 3,
@@ -58,6 +61,7 @@ describe("server/getters/get-user-trading-positions", () => {
         "numSharesAdjustedForUserIntention": 0,
         "realizedProfitLoss": 0,
         "unrealizedProfitLoss": 0,
+        "averagePrice": 0,
       }, {
         "marketID": "0x0000000000000000000000000000000000000001",
         "outcome": 4,
@@ -65,6 +69,7 @@ describe("server/getters/get-user-trading-positions", () => {
         "numSharesAdjustedForUserIntention": 0,
         "realizedProfitLoss": 0,
         "unrealizedProfitLoss": 0,
+        "averagePrice": 0,
       }, {
         "marketID": "0x0000000000000000000000000000000000000001",
         "outcome": 5,
@@ -72,6 +77,7 @@ describe("server/getters/get-user-trading-positions", () => {
         "numSharesAdjustedForUserIntention": 0,
         "realizedProfitLoss": 0,
         "unrealizedProfitLoss": 0,
+        "averagePrice": 0,
       }, {
         "marketID": "0x0000000000000000000000000000000000000001",
         "outcome": 6,
@@ -79,6 +85,7 @@ describe("server/getters/get-user-trading-positions", () => {
         "numSharesAdjustedForUserIntention": 0,
         "realizedProfitLoss": 0,
         "unrealizedProfitLoss": 0,
+        "averagePrice": 0,
       }, {
         "marketID": "0x0000000000000000000000000000000000000001",
         "outcome": 7,
@@ -86,6 +93,7 @@ describe("server/getters/get-user-trading-positions", () => {
         "numSharesAdjustedForUserIntention": 0,
         "realizedProfitLoss": 0,
         "unrealizedProfitLoss": 0,
+        "averagePrice": 0,
       }]);
     },
   });
@@ -109,6 +117,7 @@ describe("server/getters/get-user-trading-positions", () => {
         "numSharesAdjustedForUserIntention": 0,
         "realizedProfitLoss": 0,
         "unrealizedProfitLoss": 0,
+        "averagePrice": 0,
       }]);
     },
   });


### PR DESCRIPTION
@stephensprinkle average price is a part of position, but is always 0. I'll implement proper value calculation, but you should be able to move forward since a value will be returned:

```
$ node test-client.js payloads/getUserTradingPositions.json

payloads/getUserTradingPositions.json
{
  "id": 6,
  "jsonrpc": "2.0",
  "method": "getUserTradingPositions",
  "params": {
    "universe": "0x6eabb9367012c0a84473e1e6d7a7ce39a54d77bb",
    "account": "0x01114f4bda09ed6c6715cf0baf606b5bce1dc96a"
  }
}

{
  "id": 6,
  "result": [
    {
      "marketID": "0xb2a096ab60fe830cb15c364914e9366d19cb7aa1",
      "outcome": 0,
      "averagePrice": 0,
      "numShares": 0.15,
      "numSharesAdjustedForUserIntention": 1.840519140054738,
      "realizedProfitLoss": 0,
      "unrealizedProfitLoss": -0.15177972552185445
    },
    {
      "marketID": "0x2abfe00349b6b0aae8c2b4a045081e1658cee797",
      "outcome": 0,
      "averagePrice": 0,
      "numShares": 0.6,
      "numSharesAdjustedForUserIntention": 1.399428440784574,
      "realizedProfitLoss": 0,
      "unrealizedProfitLoss": -0.1717421183873354
    },
    {...
```