### PR TITLE
fixing bug related to endpoints

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,7 @@ checkAugurDbSetup(db, (err?: Error|null): void => {
     websocketServer.close();
     process.exit(1);
   }
-  syncAugurNodeWithBlockchain(db, augur, ethereumNodeEndpoints, uploadBlockNumbers, (err?: Error|null): void => {
+  syncAugurNodeWithBlockchain(db, augur, configuredEndpoints, uploadBlockNumbers, (err?: Error|null): void => {
     if (err) {
       console.error("syncAugurNodeWithBlockchain:", err);
       websocketServer.close();


### PR DESCRIPTION
This bug existed before. When the merged object was created, it was NOT the one used to connect.