### PR TITLE
bump sqlite3 version to one with available binary for node latest (9.3.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "pg": "7.3.0",
     "postinstall-build": "5.0.1",
     "speedomatic": "2.1.1",
-    "sqlite3": "3.1.8",
+    "sqlite3": "3.1.13",
     "uuid": "3.1.0",
     "ws": "3.2.0"
   },


### PR DESCRIPTION
Referenced GitHub issue: https://github.com/mapbox/node-sqlite3/issues/918

Confirmed this as working in both Mac + Linux environments against node latests + lts.