### PR TITLE
just updating get-markets for now. Some other methods could be deprecated for the most part

### DIFF
--- a/src/server/dispatch-json-rpc-request.ts
+++ b/src/server/dispatch-json-rpc-request.ts
@@ -68,7 +68,7 @@ export function dispatchJsonRpcRequest(db: Knex, request: JsonRpcRequest, augur:
     case "getMarketsClosingInDateRange":
       return getMarketsClosingInDateRange(db, request.params.earliestClosingTime, request.params.latestClosingTime, request.params.universe, request.params.sortBy, request.params.isSortDescending, request.params.limit, request.params.offset, callback);
     case "getMarkets":
-      return getMarkets(db, request.params.universe, request.params.sortBy, request.params.isSortDescending, request.params.limit, request.params.offset, callback);
+      return getMarkets(db, request.params.universe, request.params.creator, request.params.category, request.params.reportingState, request.params.feeWindow, request.params.designatedReporter, request.params.sortBy, request.params.isSortDescending, request.params.limit, request.params.offset, callback);
     case "getMarketsInfo":
       return getMarketsInfo(db, request.params.marketIDs, callback);
     case "getOrders":

--- a/src/server/getters/get-markets.ts
+++ b/src/server/getters/get-markets.ts
@@ -3,10 +3,15 @@ import { Address, MarketsContractAddressRow } from "../../types";
 import { queryModifier, getMarketsWithReportingState } from "./database";
 
 // Returning marketIDs should likely be more generalized, since it is a single line change for most getters (awaiting reporting, by user, etc)
-export function getMarkets(db: Knex, universe: Address, sortBy: string|null|undefined, isSortDescending: boolean|null|undefined, limit: number|null|undefined, offset: number|null|undefined, callback: (err?: Error|null, result?: any) => void): void {
+export function getMarkets(db: Knex, universe: Address, creator: Address|null|undefined, category: string|null|undefined, reportingState: string|null|undefined, feeWindow: Address|null|undefined, designatedReporter: Address|null|undefined, sortBy: string|null|undefined, isSortDescending: boolean|null|undefined, limit: number|null|undefined, offset: number|null|undefined, callback: (err?: Error|null, result?: any) => void): void {
   if (universe == null) return callback(new Error("Must provide universe"));
   let query = getMarketsWithReportingState(db, ["markets.marketID"]);
   if (universe != null) query = query.where({ universe });
+  if (creator != null) query = query.where({ marketCreator: creator });
+  if (category != null) query = query.where({ category });
+  if (reportingState != null) query = query.where({ reportingState });
+  if (feeWindow != null) query = query.where({ feeWindow });
+  if (designatedReporter != null) query = query.where({ designatedReporter });
 
   query = queryModifier(query, "volume", "desc", sortBy, isSortDescending, limit, offset);
   query.asCallback((err?: Error|null, marketsRows?: Array<MarketsContractAddressRow>): void => {

--- a/src/server/run-server.ts
+++ b/src/server/run-server.ts
@@ -28,7 +28,7 @@ export function runServer(db: Knex, augur: Augur): RunServerResult {
       const networkId: string = augur.rpc.getNetworkID();
       const universe: Address = augur.contracts.addresses[networkId].Universe;
 
-      getMarkets(db, universe, undefined, undefined, undefined, undefined, (err: Error|null, result?: any): void => {
+      getMarkets(db, universe, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, (err: Error|null, result?: any): void => {
         if (err || result.length === 0) {
           res.send( { status: "down", reason: err || "No markets found", universe });
         } else {

--- a/test/server/getters/get-markets.js
+++ b/test/server/getters/get-markets.js
@@ -10,7 +10,7 @@ describe("server/getters/get-markets", () => {
     it(t.description, (done) => {
       setupTestDb((err, db) => {
         if (err) assert.fail(err);
-        getMarkets(db, t.params.universe, t.params.sortBy, t.params.isSortDescending, t.params.limit, t.params.offset, (err, marketsMatched) => {
+        getMarkets(db, t.params.universe, t.params.creator, t.params.category, t.params.reportingState, t.params.feeWindow, t.params.designatedReporter, t.params.sortBy, t.params.isSortDescending, t.params.limit, t.params.offset, (err, marketsMatched) => {
           t.assertions(err, marketsMatched);
           done();
         });
@@ -50,6 +50,196 @@ describe("server/getters/get-markets", () => {
     assertions: (err, marketsMatched) => {
       assert.isNull(err);
       assert.deepEqual(marketsMatched, []);
+    },
+  });
+  test({
+    description: "user has created 3 markets",
+    params: {
+      universe: "0x000000000000000000000000000000000000000b",
+      creator: "0x0000000000000000000000000000000000000b0b",
+    },
+    assertions: (err, marketsCreatedByUser) => {
+      assert.isNull(err);
+      assert.deepEqual(marketsCreatedByUser, [
+        "0x0000000000000000000000000000000000000012",
+        "0x0000000000000000000000000000000000000013",
+        "0x0000000000000000000000000000000000000014",
+        "0x0000000000000000000000000000000000000015",
+        "0x0000000000000000000000000000000000000016",
+        "0x0000000000000000000000000000000000000017",
+        "0x0000000000000000000000000000000000000018",
+        "0x0000000000000000000000000000000000000019",
+        "0x0000000000000000000000000000000000000001",
+        "0x0000000000000000000000000000000000000002",
+        "0x0000000000000000000000000000000000000011",
+        "0x0000000000000000000000000000000000000211",
+        "0x0000000000000000000000000000000000000222",
+      ]);
+    },
+  });
+  test({
+    description: "user has created 1 market",
+    params: {
+      universe: "0x000000000000000000000000000000000000000b",
+      creator: "0x000000000000000000000000000000000000d00d",
+    },
+    assertions: (err, marketsCreatedByUser) => {
+      assert.isNull(err);
+      assert.deepEqual(marketsCreatedByUser, [
+        "0x0000000000000000000000000000000000000003",
+      ]);
+    },
+  });
+  test({
+    description: "user has not created any markets",
+    params: {
+      universe: "0x000000000000000000000000000000000000000b",
+      creator: "0x0000000000000000000000000000000000000bbb",
+    },
+    assertions: (err, marketsCreatedByUser) => {
+      assert.isNull(err);
+      assert.deepEqual(marketsCreatedByUser, []);
+    },
+  });
+  test({
+    description: "category with markets in it",
+    params: {
+      universe: "0x000000000000000000000000000000000000000b",
+      category: "test category",
+    },
+    assertions: (err, marketsInCategory) => {
+      assert.isNull(err);
+      assert.deepEqual(marketsInCategory, [
+        "0x0000000000000000000000000000000000000012",
+        "0x0000000000000000000000000000000000000013",
+        "0x0000000000000000000000000000000000000014",
+        "0x0000000000000000000000000000000000000015",
+        "0x0000000000000000000000000000000000000016",
+        "0x0000000000000000000000000000000000000017",
+        "0x0000000000000000000000000000000000000018",
+        "0x0000000000000000000000000000000000000019",
+        "0x0000000000000000000000000000000000000001",
+        "0x0000000000000000000000000000000000000002",
+        "0x0000000000000000000000000000000000000003",
+        "0x0000000000000000000000000000000000000011",
+        "0x0000000000000000000000000000000000000211",
+        "0x0000000000000000000000000000000000000222",
+      ]);
+    },
+  });
+  test({
+    description: "category with markets in it, limit 2",
+    params: {
+      universe: "0x000000000000000000000000000000000000000b",
+      category: "test category",
+      limit: 2,
+    },
+    assertions: (err, marketsInCategory) => {
+      assert.isNull(err);
+      assert.deepEqual(marketsInCategory, [
+        "0x0000000000000000000000000000000000000012",
+        "0x0000000000000000000000000000000000000013",
+      ]);
+    },
+  });
+  test({
+    description: "empty category",
+    params: {
+      universe: "0x000000000000000000000000000000000000000b",
+      category: "empty category",
+    },
+    assertions: (err, marketsInCategory) => {
+      assert.isNull(err);
+      assert.deepEqual(marketsInCategory, []);
+    },
+  });
+  test({
+    description: "get markets upcoming, unknown designated reporter",
+    params: {
+      universe: "0x000000000000000000000000000000000000000b",
+      reportingState: "PRE_REPORTING",
+      designatedReporter: "0xf0f0f0f0f0f0f0f0b0b0b0b0b0b0b0f0f0f0f0b0",
+    },
+    assertions: (err, marketsUpcomingDesignatedReporting) => {
+      assert.isNull(err);
+      assert.deepEqual(marketsUpcomingDesignatedReporting, []);
+    },
+  });
+  test({
+    description: "get all markets upcoming designated reporting, sorted ascending by volume",
+    params: {
+      universe: "0x000000000000000000000000000000000000000b",
+      reportingState: "PRE_REPORTING",
+      sortBy: "volume",
+      isSortDescending: false,
+    },
+    assertions: (err, marketsUpcomingDesignatedReporting) => {
+      assert.isNull(err);
+      assert.deepEqual(marketsUpcomingDesignatedReporting, [
+        "0x0000000000000000000000000000000000000222",
+      ]);
+    },
+  });
+  test({
+    description: "get all markets upcoming designated reporting by b0b",
+    params: {
+      universe: "0x000000000000000000000000000000000000000b",
+      reportingState: "PRE_REPORTING",
+      designatedReporter: "0x0000000000000000000000000000000000000b0b",
+    },
+    assertions: (err, marketsInfo) => {
+      assert.isNull(err);
+      assert.deepEqual(marketsInfo, [
+        "0x0000000000000000000000000000000000000222",
+      ]);
+    },
+  });
+  test({
+    description: "get markets awaiting unknown designated reporter",
+    params: {
+      universe: "0x000000000000000000000000000000000000000b",
+      reportingState: "DESIGNATED_REPORTING",
+      designatedReporter: "0xf0f0f0f0f0f0f0f0b0b0b0b0b0b0b0f0f0f0f0b0",
+    },
+    assertions: (err, marketsAwaitingDesignatedReporting) => {
+      assert.isNull(err);
+      assert.deepEqual(marketsAwaitingDesignatedReporting, []);
+    },
+  });
+  test({
+    description: "get all markets awaiting designated reporting, sorted ascending by volume",
+    params: {
+      universe: "0x000000000000000000000000000000000000000b",
+      reportingState: "DESIGNATED_REPORTING",
+      sortBy: "volume",
+      isSortDescending: false,
+    },
+    assertions: (err, marketsInfo) => {
+      assert.isNull(err);
+      assert.deepEqual(marketsInfo, [
+        "0x0000000000000000000000000000000000000001",
+        "0x0000000000000000000000000000000000000002",
+        "0x0000000000000000000000000000000000000003",
+        "0x0000000000000000000000000000000000000012",
+        "0x0000000000000000000000000000000000000014",
+        "0x0000000000000000000000000000000000000015",
+        "0x0000000000000000000000000000000000000016",
+        "0x0000000000000000000000000000000000000017",
+      ]);
+    },
+  });
+  test({
+    description: "get all markets awaiting designated reporting by d00d",
+    params: {
+      universe: "0x000000000000000000000000000000000000000b",
+      reportingState: "DESIGNATED_REPORTING",
+      designatedReporter: "0x000000000000000000000000000000000000d00d",
+    },
+    assertions: (err, marketsInfo) => {
+      assert.isNull(err);
+      assert.deepEqual(marketsInfo, [
+        "0x0000000000000000000000000000000000000003",
+      ]);
     },
   });
 });


### PR DESCRIPTION
This will allow the UI to filter all market requests by creator for the bug bounty. May provide useful to have one big generic method for other reasons too.