### PR TITLE
join market_state blockNumber to blocks, to allow sorting by a market's last state change

### DIFF
--- a/scripts/payloads/getMarkets-finalized.json
+++ b/scripts/payloads/getMarkets-finalized.json
@@ -1,0 +1,8 @@
+{ "id": 913,
+  "jsonrpc": "2.0",
+  "method": "getMarkets",
+  "params": 
+   { "universe": "0xf7a6dff0f7777cdbf2d1c3b99e0ed08f09d49818",
+     "reportingState": "FINALIZED",
+     "sortBy": "reportingStateUpdatedOn",
+     "isSortDescending": true } }

--- a/src/blockchain/log-processors/order-filled/update-orders-and-positions.ts
+++ b/src/blockchain/log-processors/order-filled/update-orders-and-positions.ts
@@ -2,7 +2,6 @@ import { Augur } from "augur.js";
 import { parallel } from "async";
 import * as Knex from "knex";
 import { Address, Bytes32, AsyncCallback, ErrorCallback } from "../../../types";
-import { upsertPositionInMarket } from "./upsert-position-in-market";
 import { convertOnChainSharesToHumanReadableShares } from "../../../utils/convert-fixed-point-to-decimal";
 import { formatOrderAmount } from "../../../utils/format-order";
 import { refreshPositionInMarket } from "./refresh-position-in-market";

--- a/src/blockchain/make-log-listener.ts
+++ b/src/blockchain/make-log-listener.ts
@@ -9,7 +9,7 @@ import { logQueueAdd } from "./process-queue";
 export function makeLogListener(augur: Augur, contractName: string, eventName: string) {
   return (log: FormattedEventLog): void => {
     console.log("log queued for block:", log.blockNumber);
-    logQueueAdd(log.blockNumber, (db, callback: ErrorCallback) => {
+    logQueueAdd(log.blockNumber, (db: Knex, callback: ErrorCallback) => {
       const logProcessor = logProcessors[contractName][eventName];
       if (!logProcessor.noAutoEmit) augurEmitter.emit(eventName, log);
       processLog(db, augur, log, logProcessors[contractName][eventName], callback);

--- a/src/server/getters/get-dispute-tokens.ts
+++ b/src/server/getters/get-dispute-tokens.ts
@@ -1,6 +1,5 @@
 import * as Knex from "knex";
-import * as _ from "lodash";
-import { Address, ReportingState, DisputeTokensRowWithTokenState, DisputeTokenState, UIDisputeTokenInfo, UIDisputeTokens } from "../../types";
+import { Address, ReportingState, DisputeTokensRowWithTokenState, DisputeTokenState, UIDisputeTokens } from "../../types";
 import { getMarketsWithReportingState, reshapeDisputeTokensRowToUIDisputeTokenInfo } from "./database";
 
 export function getDisputeTokens(db: Knex, universe: Address, account: Address, disputeTokenState: DisputeTokenState|null, callback: (err: Error|null, result?: any) => void): void {

--- a/src/server/getters/get-markets.ts
+++ b/src/server/getters/get-markets.ts
@@ -5,15 +5,16 @@ import { queryModifier, getMarketsWithReportingState } from "./database";
 // Returning marketIds should likely be more generalized, since it is a single line change for most getters (awaiting reporting, by user, etc)
 export function getMarkets(db: Knex, universe: Address, creator: Address|null|undefined, category: string|null|undefined, reportingState: string|null|undefined, feeWindow: Address|null|undefined, designatedReporter: Address|null|undefined, sortBy: string|null|undefined, isSortDescending: boolean|null|undefined, limit: number|null|undefined, offset: number|null|undefined, callback: (err?: Error|null, result?: any) => void): void {
   if (universe == null) return callback(new Error("Must provide universe"));
-  let query = getMarketsWithReportingState(db, ["markets.marketId"]);
-  if (universe != null) query = query.where({ universe });
-  if (creator != null) query = query.where({ marketCreator: creator });
-  if (category != null) query = query.where({ category });
-  if (reportingState != null) query = query.where({ reportingState });
-  if (feeWindow != null) query = query.where({ feeWindow });
-  if (designatedReporter != null) query = query.where({ designatedReporter });
+  const query = getMarketsWithReportingState(db, ["markets.marketId", "marketStateBlock.timestamp as reportingStateUpdatedOn"]);
+  query.join("blocks as marketStateBlock", "marketStateBlock.blockNumber", "market_state.blockNumber");
+  if (universe != null) query.where({ universe });
+  if (creator != null) query.where({ marketCreator: creator });
+  if (category != null) query.where({ category });
+  if (reportingState != null) query.where({ reportingState });
+  if (feeWindow != null) query.where({ feeWindow });
+  if (designatedReporter != null) query.where({ designatedReporter });
 
-  query = queryModifier(query, "volume", "desc", sortBy, isSortDescending, limit, offset);
+  queryModifier(query, "volume", "desc", sortBy, isSortDescending, limit, offset);
   query.asCallback((err?: Error|null, marketsRows?: Array<MarketsContractAddressRow>): void => {
     if (err) return callback(err);
     if (!marketsRows) return callback(null);

--- a/test/server/getters/get-markets.js
+++ b/test/server/getters/get-markets.js
@@ -229,6 +229,28 @@ describe("server/getters/get-markets", () => {
     },
   });
   test({
+    description: "get all markets awaiting designated reporting, sorted ascending by reportingStateUpdatedOn",
+    params: {
+      universe: "0x000000000000000000000000000000000000000b",
+      reportingState: "DESIGNATED_REPORTING",
+      sortBy: "reportingStateUpdatedOn",
+      isSortDescending: true,
+    },
+    assertions: (err, marketsInfo) => {
+      assert.isNull(err);
+      assert.deepEqual(marketsInfo, [
+        "0x0000000000000000000000000000000000000003",
+        "0x0000000000000000000000000000000000000012",
+        "0x0000000000000000000000000000000000000014",
+        "0x0000000000000000000000000000000000000015",
+        "0x0000000000000000000000000000000000000016",
+        "0x0000000000000000000000000000000000000017",
+        "0x0000000000000000000000000000000000000002",
+        "0x0000000000000000000000000000000000000001",
+      ]);
+    },
+  });
+  test({
     description: "get all markets awaiting designated reporting by d00d",
     params: {
       universe: "0x000000000000000000000000000000000000000b",


### PR DESCRIPTION
@stephensprinkle I wanted to see if you thought this was acceptable

```
{ "id": 913,
  "jsonrpc": "2.0",
  "method": "getMarkets",
  "params": 
   { "universe": "0xf7a6dff0f7777cdbf2d1c3b99e0ed08f09d49818",
     "reportingState": "FINALIZED",
     "sortBy": "reportingStateUpdatedOn",
     "isSortDescending": true } }

{
  "id": 913,
  "result": [
    "0x17503d4d710a194aba90d12fec0d353ea7c3ad46",
    "0xd60285796b8866e1d9f1fa184b6b77a873ff75dd",
    "0xd0558a83e061d8762187725d2b527d42705b3b99",
    "0x424b423fb83cbde3c96610bdaf4585c38874765e",
    "0x5d68e66b61b90d021ada750c293bb3d983564eea",
    "0xa26645b72f7cef94a0989aa4f912557f8d983677",
    "0xbff502ecddaf21c75a19ff848ca66d9879d5dfa9",
    "0x6ad025e6d606cc52e598b278b5c18a001de2c77a",
    "0x9e04f32e06213bd95b35f43bd560ee87b0d8a11b",
    "0x65f40d6836f87fcb647dc25adf063c985222f688",
    "0x896937450b07e22856360d5e93180fa539368782",
    "0xfc9b922e889799723de3c6b886eede770cfb423d",
    "0x67aeebb0d2192d4707c05a8569b9005648a09fca",
    "0x174a121d6b18343fed325f81d557d02afc98d898",
    "0x82a37c54267b1e9d94c37895fe26ec232aa55030"
  ],
  "jsonrpc": "2.0"
}

```