### PR TITLE
Fix block/log processing for bulk load 

### DIFF
--- a/src/blockchain/download-augur-logs.ts
+++ b/src/blockchain/download-augur-logs.ts
@@ -1,6 +1,7 @@
 import { Augur } from "augur.js";
 import { eachSeries } from "async";
 import * as Knex from "knex";
+import * as _ from "lodash";
 import { ErrorCallback, FormattedEventLog } from "../types";
 import { processLog } from "./process-logs";
 import { logProcessors } from "./log-processors";
@@ -10,27 +11,36 @@ export function downloadAugurLogs(db: Knex, augur: Augur, fromBlock: number, toB
   console.log("Getting Augur logs from block " + fromBlock + " to block " + toBlock);
   augur.events.getAllAugurLogs({ fromBlock, toBlock }, (err?: string|object|null, allAugurLogs?: Array<FormattedEventLog>): void => {
     if (err) return callback(err instanceof Error ? err : new Error(JSON.stringify(err)));
-    const blockNumbers = allAugurLogs!.reduce( (set, log) => set.add(log.blockNumber), new Set<number>() );
-    eachSeries(Array.from(blockNumbers), (blockNumber: number, nextBlock: ErrorCallback): void => processBlockByNumber(db, augur, blockNumber, nextBlock) );
-    eachSeries(allAugurLogs!, (log: FormattedEventLog, nextLog: ErrorCallback) => {
-      const contractName = log.contractName;
-      const eventName = log.eventName;
-      if (logProcessors[contractName] == null || logProcessors[contractName][eventName] == null) {
-        console.log("Log processor does not exist:", contractName, eventName);
-        nextLog();
-      } else {
-        db.transaction((trx: Knex.Transaction): void => {
-          processLog(trx, augur, log, logProcessors[contractName][eventName], (err?: Error|null): void => {
+    if (!allAugurLogs) return callback(null);
+    const blockNumbers = allAugurLogs.reduce((set, log) => set.add(log.blockNumber), new Set<number>());
+    const logsByBlock: { [blockNumber: number]: Array<FormattedEventLog> } = _.groupBy(allAugurLogs, (log) => log.blockNumber);
+    eachSeries(Array.from(blockNumbers), (blockNumber: number, nextBlock: ErrorCallback) => {
+      const logs = logsByBlock[blockNumber];
+      db.transaction((trx: Knex.Transaction): void => {
+        processBlockByNumber(trx, augur, blockNumber, (err: Error|null) => {
+          if (err) {
+            return nextBlock(err);
+          }
+          eachSeries(logs, (log: FormattedEventLog, nextLog: ErrorCallback) => {
+            const contractName = log.contractName;
+            const eventName = log.eventName;
+            if (logProcessors[contractName] == null || logProcessors[contractName][eventName] == null) {
+              console.log("Log processor does not exist:", contractName, eventName);
+              nextLog();
+            } else {
+              processLog(trx, augur, log, logProcessors[contractName][eventName], nextLog);
+            }
+          }, (err: Error|null) => {
             if (err) {
               trx.rollback(err);
-              nextLog(err);
+              return nextBlock(err);
             } else {
               trx.commit();
-              nextLog();
+              return nextBlock();
             }
           });
         });
-      }
+      });
     }, callback);
   });
 }

--- a/src/blockchain/process-logs.ts
+++ b/src/blockchain/process-logs.ts
@@ -6,7 +6,3 @@ import { FormattedEventLog, EventLogProcessor, ErrorCallback } from "../types";
 export function processLog(db: Knex, augur: Augur, log: FormattedEventLog, logProcessor: EventLogProcessor, callback: ErrorCallback): void {
   (!log.removed ? logProcessor.add : logProcessor.remove)(db, augur, log, callback);
 }
-
-export function processLogs(db: Knex, augur: Augur, logs: Array<FormattedEventLog>, logProcessor: EventLogProcessor, callback: ErrorCallback): void {
-  eachSeries(logs, (log: FormattedEventLog, nextLog: ErrorCallback): void => processLog(db, augur, log, logProcessor, nextLog), callback);
-}

--- a/src/server/getters/get-initial-reporters.ts
+++ b/src/server/getters/get-initial-reporters.ts
@@ -1,7 +1,6 @@
 import * as Knex from "knex";
 import Augur from "augur.js";
 import { Address } from "../../types";
-import { queryModifier } from "./database";
 import { InitialReportersRow, UIInitialReporters } from "../../types";
 
 export function getInitialReporters(db: Knex, augur: Augur, reporter: Address, redeemed: boolean|null|undefined, withRepBalance: boolean|null|undefined, callback: (err: Error|null, result?: any) => void): void {


### PR DESCRIPTION
significantly improve bulk downloading. Before, blocks were downloaded outside of a transaction, and EACH log was processed inside a transaction (not a block's worth)

This makes transactions block-oriented, as well as ensuring the correct
block-logs-block-logs sequential ordering (necessary for advancing time sensibly), and if it stops in the middle, we'll know where to pick up from without duplicating data