### PR TITLE
we use same log process for native and Augur-based transers. respect logic in remove

### DIFF
--- a/src/blockchain/log-processors/tokens-transferred.ts
+++ b/src/blockchain/log-processors/tokens-transferred.ts
@@ -37,9 +37,11 @@ export function processTokensTransferredLogRemoval(db: Knex, augur: Augur, log: 
   db.from("transfers").where({ transactionHash: log.transactionHash, logIndex: log.logIndex }).del().asCallback((err: Error|null): void => {
     if (err) return callback(err);
     augurEmitter.emit("TokensTransferred", log);
+    const token = log.token || log.address;
+    const value = log.value || log.amount;
     parallel([
-      (next: AsyncCallback): void => increaseTokenBalance(db, augur, log.token, log.from, Number(log.value), next),
-      (next: AsyncCallback): void => decreaseTokenBalance(db, augur, log.token, log.to, Number(log.value), next),
+      (next: AsyncCallback): void => increaseTokenBalance(db, augur, token, log.from, Number(value), next),
+      (next: AsyncCallback): void => decreaseTokenBalance(db, augur, token, log.to, Number(value), next),
     ], (err: Error|null): void => {
       if (err) return callback(err);
       handleShareTokenTransfer(db, augur, log, callback);


### PR DESCRIPTION
Sometimes this processor receives for Augur.TokensTransferred. Sometimes it receives LegacyRepToken.Transferred. There is slightly different data formats for those, and remove wasn't being flexible