### PR TITLE
Fix get dispute

### DIFF
--- a/src/blockchain/log-processors/crowdsourcer.ts
+++ b/src/blockchain/log-processors/crowdsourcer.ts
@@ -8,12 +8,12 @@ import { parallel } from "async";
 
 function updateTentativeWinningPayout(db: Knex, marketId: Address, callback: ErrorCallback) {
   const query = db.first(["payoutId", "amountStaked"]).from((builder: QueryBuilder) =>
-    builder.from("crowdsourcers").select("payoutId", "amountStaked").where({
+    builder.from("crowdsourcers").select(["payoutId", "amountStaked"]).where({
       completed: 1,
       marketId,
     }).union((builder: QueryBuilder) =>
       builder.select(["payoutId", "amountStaked"]).from("initial_reports").where("marketId", marketId),
-    )).orderBy("sum(amountStaked)", "desc").groupBy("payoutId");
+    )).orderByRaw("sum(amountStaked) desc").groupBy("payoutId");
   query.asCallback((err: Error|null, mostStakedPayoutId) => {
     if (err) return callback(err);
     parallel([

--- a/src/blockchain/log-processors/database.ts
+++ b/src/blockchain/log-processors/database.ts
@@ -41,10 +41,10 @@ export function insertPayout(db: Knex, marketId: Address, payoutNumerators: Arra
   payoutNumerators.forEach((value: number, i: number): void => {
     payoutRow["payout" + i] = value;
   });
-  db.select("payoutId").from("payouts").where(payoutRow).first().asCallback( (err: Error|null, payoutId?: number|null): void => {
+  db.select("payoutId").from("payouts").where(payoutRow).first().asCallback( (err: Error|null, payoutIdRow?: {payoutId: number}|null): void => {
     if (err) return callback(err);
-    if (payoutId != null) {
-      return callback(null, payoutId);
+    if (payoutIdRow != null) {
+      return callback(null, payoutIdRow.payoutId);
     } else {
       db.insert(payoutRow).returning("payoutId").into("payouts").asCallback((err: Error|null, payoutIdRow?: Array<number>): void => {
         if (err) callback(err);

--- a/src/server/getters/get-dispute-info.ts
+++ b/src/server/getters/get-dispute-info.ts
@@ -47,9 +47,9 @@ function isActiveMarketState(reportingState: ReportingState|null|undefined) {
 }
 
 function calculateBondSize(totalCompletedStakeOnAllPayouts: BigNumber, completedStakeAmount: BigNumber): BigNumber {
-  return new BigNumber(totalCompletedStakeOnAllPayouts.times(2))
+  return new BigNumber(totalCompletedStakeOnAllPayouts.times(2).toString())
     .minus(
-      new BigNumber(completedStakeAmount).times(3));
+      new BigNumber(completedStakeAmount).times(3).toString());
 }
 
 export function getDisputeInfo(db: Knex, marketIds: Array<Address>, account: Address|null, callback: (err: Error|null, result?: Array<UIStakeInfo|null>) => void): void {
@@ -91,7 +91,7 @@ function reshapeStakeRowToUIStakeInfo(stakeRows: DisputesResult): UIStakeInfo|nu
     return null;
   }
   const totalCompletedStakeOnAllPayouts = new BigNumber(
-    _.sum(_.map(stakeRows.completedStakes, (completedStake) => completedStake.amountStaked)));
+    _.sum(_.map(stakeRows.completedStakes, (completedStake) => completedStake.amountStaked)).toString());
 
   const completedStakeByPayout: { [payoutId: number]: StakeRow } = _.keyBy(stakeRows.completedStakes, "payoutId");
   const activeCrowdsourcerByPayout: { [payoutId: number]: ActiveCrowdsourcer } = _.keyBy(stakeRows.activeCrowdsourcer, "payoutId");
@@ -104,8 +104,8 @@ function reshapeStakeRowToUIStakeInfo(stakeRows: DisputesResult): UIStakeInfo|nu
     const accountStakeComplete = accountStakeCompleteByPayout[payout.payoutId];
     const accountStakeIncomplete = accountStakeIncompleteByPayout[payout.payoutId];
 
-    const completedStakeAmount = new BigNumber(completedStakes == null ? 0 : completedStakes.amountStaked);
-    const totalStakeOnPayout = completedStakeAmount.add(new BigNumber(activeCrowdsourcer == null ? 0 : activeCrowdsourcer.amountStaked));
+    const completedStakeAmount = new BigNumber(completedStakes == null ? 0 : completedStakes.amountStaked.toString());
+    const totalStakeOnPayout = completedStakeAmount.add(new BigNumber(activeCrowdsourcer == null ? 0 : activeCrowdsourcer.amountStaked.toString()));
 
     let currentAmounts: StakeSizes;
     if (payout.tentativeWinning === 1 || !isActiveMarketState(marketRow.reportingState)) {
@@ -118,13 +118,13 @@ function reshapeStakeRowToUIStakeInfo(stakeRows: DisputesResult): UIStakeInfo|nu
       };
     } else {
       currentAmounts = {
-        size: new BigNumber(activeCrowdsourcer.size).toFixed(),
-        currentStake: new BigNumber(activeCrowdsourcer.amountStaked).toFixed(),
-        accountStakeIncomplete: new BigNumber(accountStakeIncomplete === undefined ? 0 : accountStakeIncomplete.amountStaked ).toFixed(),
+        size: new BigNumber(activeCrowdsourcer.size.toString()).toFixed(),
+        currentStake: new BigNumber(activeCrowdsourcer.amountStaked.toString()).toFixed(),
+        accountStakeIncomplete: new BigNumber(accountStakeIncomplete === undefined ? 0 : accountStakeIncomplete.amountStaked.toString() ).toFixed(),
       };
     }
 
-    currentAmounts.accountStakeComplete = new BigNumber(accountStakeComplete === undefined ? 0 : accountStakeComplete.amountStaked).toFixed();
+    currentAmounts.accountStakeComplete = new BigNumber(accountStakeComplete === undefined ? 0 : accountStakeComplete.amountStaked.toString()).toFixed();
     return Object.assign({},
       normalizePayouts(payout),
       currentAmounts,


### PR DESCRIPTION
This issue resolves two different issues:
1.) The calculation of which payout had the largest stake was bad, it was sorting on the string literal "sum(amountStaked)" which would randomly select (this would contribute to negative sizes if we didn't flag tentative winning) 
2.) Another crowdsourcer with the same payout would return the wrong object. 