### PR TITLE
fix insert payouts

### DIFF
--- a/src/blockchain/log-processors/database.ts
+++ b/src/blockchain/log-processors/database.ts
@@ -36,17 +36,20 @@ export function insertPayout(db: Knex, marketId: Address, payoutNumerators: Arra
   const payoutRow: { [index: string]: string|number|boolean|null } = {
     marketId,
     isInvalid: invalid,
-    tentativeWinning,
   };
-  payoutNumerators.forEach((value: number, i: number): void => {
-    payoutRow["payout" + i] = value;
+  payoutNumerators.forEach((value: string, i: number): void => {
+    payoutRow["payout" + i] = parseInt(value, 10);
   });
   db.select("payoutId").from("payouts").where(payoutRow).first().asCallback( (err: Error|null, payoutIdRow?: {payoutId: number}|null): void => {
     if (err) return callback(err);
     if (payoutIdRow != null) {
       return callback(null, payoutIdRow.payoutId);
     } else {
-      db.insert(payoutRow).returning("payoutId").into("payouts").asCallback((err: Error|null, payoutIdRow?: Array<number>): void => {
+      const payoutRowWithTentativeWinning = Object.assign( {},
+        payoutRow,
+        {tentativeWinning}
+        );
+      db.insert(payoutRowWithTentativeWinning).returning("payoutId").into("payouts").asCallback((err: Error|null, payoutIdRow?: Array<number>): void => {
         if (err) callback(err);
         if (!payoutIdRow || !payoutIdRow.length) return callback(new Error("No payoutId returned"));
         callback(err, payoutIdRow[0]);

--- a/src/blockchain/log-processors/database.ts
+++ b/src/blockchain/log-processors/database.ts
@@ -47,7 +47,7 @@ export function insertPayout(db: Knex, marketId: Address, payoutNumerators: Arra
     } else {
       const payoutRowWithTentativeWinning = Object.assign( {},
         payoutRow,
-        {tentativeWinning}
+        {tentativeWinning},
         );
       db.insert(payoutRowWithTentativeWinning).returning("payoutId").into("payouts").asCallback((err: Error|null, payoutIdRow?: Array<number>): void => {
         if (err) callback(err);

--- a/src/blockchain/log-processors/database.ts
+++ b/src/blockchain/log-processors/database.ts
@@ -38,7 +38,8 @@ export function insertPayout(db: Knex, marketId: Address, payoutNumerators: Arra
     marketId,
     isInvalid: invalid,
   };
-  payoutNumerators.forEach((value: string, i: number): void => {
+  payoutNumerators.forEach((value, i): void => {
+    if (value == null) return;
     payoutRow["payout" + i] = new BigNumber(value, 10).toFixed();
   });
   db.select("payoutId").from("payouts").where(payoutRow).first().asCallback( (err: Error|null, payoutIdRow?: {payoutId: number}|null): void => {

--- a/src/blockchain/log-processors/database.ts
+++ b/src/blockchain/log-processors/database.ts
@@ -1,5 +1,6 @@
 import * as Knex from "knex";
 import { Address, ReportingState, AsyncCallback } from "../../types";
+import { BigNumber } from "bignumber.js";
 
 function queryCurrentMarketStateId(db: Knex, marketId: Address) {
   return db("market_state").max("marketStateId as latestMarketStateId").first().where({ marketId });
@@ -38,7 +39,7 @@ export function insertPayout(db: Knex, marketId: Address, payoutNumerators: Arra
     isInvalid: invalid,
   };
   payoutNumerators.forEach((value: string, i: number): void => {
-    payoutRow["payout" + i] = parseInt(value, 10);
+    payoutRow["payout" + i] = new BigNumber(value, 10).toFixed();
   });
   db.select("payoutId").from("payouts").where(payoutRow).first().asCallback( (err: Error|null, payoutIdRow?: {payoutId: number}|null): void => {
     if (err) return callback(err);


### PR DESCRIPTION
Simple mistake, was making tentativeWinning part of the required insert. This is actually sort of an artifact of the contract event ordering issue, because the payout tentativeWinning SHOULD match what is attempting to be inserted, but it doesn't. Either way, this is more correct 