### PR TITLE
Add repStaked/Earned to getReportingFees

### DIFF
--- a/src/server/getters/get-reporting-fees.ts
+++ b/src/server/getters/get-reporting-fees.ts
@@ -12,6 +12,7 @@ export interface FeeDetails {
     unclaimedEth: string;
     unclaimedRepStaked: string;
     unclaimedRepEarned: string;
+    lostRep: string;
     claimedEth: string;
     claimedRepStaked: string;
     claimedRepEarned: string;
@@ -49,6 +50,18 @@ interface CrowdsourcersRow {
   amountStaked: BigNumber;
 }
 
+interface FeeWindowCompletionStakeRow {
+  feeWindow: string;
+  amountStaked: BigNumber;
+  winning: number;
+}
+
+interface RepStakeResults {
+  unclaimedRepStaked: BigNumber;
+  unclaimedRepEarned: BigNumber;
+  lostRep: BigNumber;
+}
+
 function getTotalFeeWindowTokens(db: Knex, augur: Augur, universe: Address|null, feeWindow: Address|null, callback: (err: Error|null, result?: { [feeWindow: string]: FeeWindowTotalTokens }) => void) {
   const query = db.select(["fee_windows.feeWindow", "participationToken.supply AS participationTokenStake", "feeToken.supply", "cash.balance"]).from("fee_windows");
   query.leftJoin("token_supply AS participationToken", "fee_windows.feeWindow", "participationToken.token");
@@ -70,6 +83,32 @@ function getTotalFeeWindowTokens(db: Knex, augur: Augur, universe: Address|null,
       };
       return acc;
     }, {}));
+  });
+}
+
+function getStakedRepResults(db: Knex, reporter: Address, universe: Address|null, feeWindow: Address|null, callback: (err: Error|null, result?: { redeemableFeeWindows: Array<string>, fees: RepStakeResults }) => void) {
+  const query = db.select(["fee_windows.feeWindow", "stakedRep.balance as amountStaked", "payouts.winning"]).from("fee_windows");
+  query.join("crowdsourcers", "crowdsourcers.feeWindow", "fee_windows.feeWindow");
+  query.join("payouts", "crowdsourcers.payoutId", "payouts.payoutId");
+  query.whereNotNull("payouts.winning");
+  query.leftJoin("balances AS stakedRep", function () {
+    this
+      .on("crowdsourcers.crowdsourcerId", db.raw("stakedRep.token"))
+      .andOn("stakedRep.owner", db.raw("?", reporter));
+  });
+  if (universe != null) query.where("fee_windows.universe", universe);
+  if (feeWindow != null) query.where("fee_windows.feeWindow", feeWindow);
+  query.asCallback((err, feeWindowCompletionStakes: Array<FeeWindowCompletionStakeRow>) => {
+    if (err) return callback(err);
+    const redeemableFeeWindows = _.uniq(_.map(feeWindowCompletionStakes, (feeWindowCompletionStake) => feeWindowCompletionStake.feeWindow));
+    const fees = _.reduce(feeWindowCompletionStakes, (acc: RepStakeResults, feeWindowCompletionStake: FeeWindowCompletionStakeRow) => {
+      return {
+        unclaimedRepStaked: acc.unclaimedRepStaked.plus(feeWindowCompletionStake.winning === 0 ? ZERO : (feeWindowCompletionStake.amountStaked || ZERO)),
+        unclaimedRepEarned: acc.unclaimedRepEarned.plus(feeWindowCompletionStake.winning === 0 ? ZERO : (feeWindowCompletionStake.amountStaked || ZERO).div(2)),
+        lostRep: acc.lostRep.plus(feeWindowCompletionStake.winning === 0 ? (feeWindowCompletionStake.amountStaked || ZERO): ZERO),
+      };
+    }, { unclaimedRepStaked: ZERO, unclaimedRepEarned: ZERO, lostRep: ZERO });
+    return callback(null, { redeemableFeeWindows, fees });
   });
 }
 
@@ -123,28 +162,33 @@ export function getReportingFees(db: Knex, augur: Augur, reporter: Address|null,
     if (err) return callback(err);
     getReporterFeeTokens(db, reporter, universe, feeWindow, (err, totalReporterTokensByFeeWindow: { [feeWindow: string]: BigNumber }) => {
       if (err) return callback(err);
-      const unclaimedEth = _.reduce(_.keys(totalReporterTokensByFeeWindow), (acc, feeWindow) => {
-        if (totalReporterTokensByFeeWindow[feeWindow].isEqualTo(ZERO)) return acc;
-        const thisFeeWindowTokens = (totalFeeWindowTokens && totalFeeWindowTokens[feeWindow]) || { totalTokens: ZERO, cashBalance: ZERO };
-        const feesForThisWindow = totalReporterTokensByFeeWindow[feeWindow].dividedBy(thisFeeWindowTokens.totalTokens).times(thisFeeWindowTokens.cashBalance);
-        acc = acc.plus(feesForThisWindow);
-        return acc;
-      }, ZERO);
-      const redeemableFeeWindows = _.keys(totalReporterTokensByFeeWindow);
-      const response = {
-        total: {
-          unclaimedEth: unclaimedEth.toFixed(),
-          unclaimedRepStaked: "2",
-          unclaimedRepEarned: "3",
-          claimedEth: "4",
-          claimedRepStaked: "5",
-          claimedRepEarned: "6",
-        },
-        feeWindows: redeemableFeeWindows,
-        crowdsourcers: [],
-        initialReporters: [],
-      };
-      callback(null, response);
+      getStakedRepResults(db, reporter, universe, feeWindow, (err, repStakeResults) => {
+        if (err || repStakeResults == null) return callback(err);
+        console.log(repStakeResults);
+        const unclaimedEth = _.reduce(_.keys(totalReporterTokensByFeeWindow), (acc, feeWindow) => {
+          if (totalReporterTokensByFeeWindow[feeWindow].isEqualTo(ZERO)) return acc;
+          const thisFeeWindowTokens = (totalFeeWindowTokens && totalFeeWindowTokens[feeWindow]) || { totalTokens: ZERO, cashBalance: ZERO };
+          const feesForThisWindow = totalReporterTokensByFeeWindow[feeWindow].dividedBy(thisFeeWindowTokens.totalTokens).times(thisFeeWindowTokens.cashBalance);
+          acc = acc.plus(feesForThisWindow);
+          return acc;
+        }, ZERO);
+        const redeemableFeeWindows = _.uniq(_.keys(totalReporterTokensByFeeWindow).concat(repStakeResults.redeemableFeeWindows));
+        const response = {
+          total: {
+            unclaimedEth: unclaimedEth.toFixed(),
+            unclaimedRepStaked: repStakeResults.fees.unclaimedRepStaked.toFixed(),
+            unclaimedRepEarned: repStakeResults.fees.unclaimedRepEarned.toFixed(),
+            lostRep: repStakeResults.fees.lostRep.toFixed(),
+            claimedEth: "4",
+            claimedRepStaked: "5",
+            claimedRepEarned: "6",
+          },
+          feeWindows: redeemableFeeWindows,
+          crowdsourcers: [],
+          initialReporters: [],
+        };
+        callback(null, response);
+      });
     });
   });
 }

--- a/src/server/getters/get-reporting-fees.ts
+++ b/src/server/getters/get-reporting-fees.ts
@@ -105,7 +105,7 @@ function getStakedRepResults(db: Knex, reporter: Address, universe: Address|null
       return {
         unclaimedRepStaked: acc.unclaimedRepStaked.plus(feeWindowCompletionStake.winning === 0 ? ZERO : (feeWindowCompletionStake.amountStaked || ZERO)),
         unclaimedRepEarned: acc.unclaimedRepEarned.plus(feeWindowCompletionStake.winning === 0 ? ZERO : (feeWindowCompletionStake.amountStaked || ZERO).div(2)),
-        lostRep: acc.lostRep.plus(feeWindowCompletionStake.winning === 0 ? (feeWindowCompletionStake.amountStaked || ZERO): ZERO),
+        lostRep: acc.lostRep.plus(feeWindowCompletionStake.winning === 0 ? (feeWindowCompletionStake.amountStaked || ZERO) : ZERO),
       };
     }, { unclaimedRepStaked: ZERO, unclaimedRepEarned: ZERO, lostRep: ZERO });
     return callback(null, { redeemableFeeWindows, fees });

--- a/test/server/getters/get-reporting-fees.js
+++ b/test/server/getters/get-reporting-fees.js
@@ -40,8 +40,9 @@ describe("server/getters/get-reporting-fees", () => {
       assert.deepEqual(marketsMatched, {
         total: {
           "unclaimedEth": "107.87878787878787879",
-          "unclaimedRepStaked": "2",
-          "unclaimedRepEarned": "3",
+          "unclaimedRepStaked": "0",
+          "unclaimedRepEarned": "0",
+          "lostRep": "0",
           "claimedEth": "4",
           "claimedRepStaked": "5",
           "claimedRepEarned": "6",
@@ -80,8 +81,9 @@ describe("server/getters/get-reporting-fees", () => {
       assert.deepEqual(marketsMatched, {
         total: {
           "unclaimedEth": "0",
-          "unclaimedRepStaked": "2",
-          "unclaimedRepEarned": "3",
+          "unclaimedRepStaked": "0",
+          "unclaimedRepEarned": "0",
+          "lostRep": "0",
           "claimedEth": "4",
           "claimedRepStaked": "5",
           "claimedRepEarned": "6",
@@ -120,8 +122,9 @@ describe("server/getters/get-reporting-fees", () => {
       assert.deepEqual(marketsMatched, {
         total: {
           "unclaimedEth": "0",
-          "unclaimedRepStaked": "2",
-          "unclaimedRepEarned": "3",
+          "unclaimedRepStaked": "0",
+          "unclaimedRepEarned": "0",
+          "lostRep": "0",
           "claimedEth": "4",
           "claimedRepStaked": "5",
           "claimedRepEarned": "6",
@@ -155,8 +158,9 @@ describe("server/getters/get-reporting-fees", () => {
       assert.deepEqual(marketsMatched, {
         total: {
           "unclaimedEth": "53.33333333333333333",
-          "unclaimedRepStaked": "2",
-          "unclaimedRepEarned": "3",
+          "unclaimedRepStaked": "0",
+          "unclaimedRepEarned": "0",
+          "lostRep": "0",
           "claimedEth": "4",
           "claimedRepStaked": "5",
           "claimedRepEarned": "6",


### PR DESCRIPTION
I'll add a tests and some general cleanup (like parallel, where possible).

```
{ "id": 913,
  "jsonrpc": "2.0",
  "method": "getReportingFees",
  "params":
   {
     "universe": "0xcd8569bb29493f01cffc394e050d2533aa5ea824",
   "reporter": "0x913da4198e6be1d5f5e4a40d0667f70c0b5430eb"
   } }

{
  "id": 913,
  "result": {
    "total": {
      "unclaimedEth": "0",
      "unclaimedRepStaked": "2098083496093750002",
      "unclaimedRepEarned": "1049041748046875001",
      "lostRep": "0",
      "claimedEth": "4",
      "claimedRepStaked": "5",
      "claimedRepEarned": "6"
    },
    "feeWindows": [
      "0x6760bfb16e7a402a94269eb60b4eca570bc14df6",
      "0x38d9a9951a8dd58c6b2479d1705b62320f0189c2",
      "0xf67f60479591f147be131a60253a691bb8e6d854",
      "0x2a9d1ed97689f14056c79ab8b33df244019b16c6",
      "0x9b9003fb915871c30a3cff62c747b43a8538b682",
      "0x0d1b6484a9b11b5b7a28ada2e5ca33cdd84841a2",
      "0x67ba56de63246d307e170a258041beb864b622c7"
    ],
    "crowdsourcers": [],
    "initialReporters": []
  },
  "jsonrpc": "2.0"
}
```