### PR TITLE
DigitalOcean one click deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![Build Status](https://travis-ci.org/AugurProject/augur-node.svg)](https://travis-ci.org/AugurProject/augur-node)
 [![Coverage Status](https://coveralls.io/repos/AugurProject/augur-node/badge.svg?branch=master&service=github)](https://coveralls.io/github/AugurProject/augur-node?branch=master)
 [![npm version](https://badge.fury.io/js/augur-node.svg)](http://badge.fury.io/js/augur-node)
+[![Install on DigitalOcean](http://installer.71m.us/button.svg)](https://installer.71m.us/install?url=https://github.com/kylewu/augur-node)
+
 
 Augur Node is designed to be a standalone application, including a local
 database setup that supports sqlite as well as postgresql. We use knex to

--- a/app.yml
+++ b/app.yml
@@ -1,0 +1,16 @@
+name: augur-node
+image: ubuntu-16-04-x64
+min_size: 1gb
+config:
+  #cloud-config
+  runcmd:
+    - apt-get install -y build-essential
+    - apt-get install -y git
+    - apt-get install -y sqlite3
+    - echo "export ENDPOINT_HTTP=https://rinkeby.ethereum.nodes.augur.net" | tee -a /root/.bashrc
+    - echo "export ENDPOINT_WS=wss://websocket-rinkeby.ethereum.nodes.augur.net" | tee -a /root/.bashrc
+    - curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
+    - apt-get install -y nodejs
+    - cd /root && git clone https://github.com/kylewu/augur-node.git 
+    - cd /root/augur-node && npm install
+    - cd /root/augur-node && export ENDPOINT_HTTP=https://rinkeby.ethereum.nodes.augur.net && export ENDPOINT_WS=wss://websocket-rinkeby.ethereum.nodes.augur.net && npm run clean-start

--- a/src/blockchain/sync-augur-node-with-blockchain.ts
+++ b/src/blockchain/sync-augur-node-with-blockchain.ts
@@ -55,8 +55,22 @@ function monitorEthereumNodeHealth(augur: Augur) {
   }, 5000);
 }
 
+const getHttpUrl = (network: NetworkConfiguration) => {
+  if (process.env.ENDPOINT_HTTP) {
+    return process.env.ENDPOINT_HTTP;
+  }
+  return network.http;
+};
+
+const getWsUrl = (network: NetworkConfiguration) => {
+  if (process.env.ENDPOINT_WS) {
+    return process.env.ENDPOINT_WS;
+  }
+  return network.ws;
+};
+
 export function syncAugurNodeWithBlockchain(db: Knex, augur: Augur, network: NetworkConfiguration, uploadBlockNumbers: UploadBlockNumbers, callback: ErrorCallback): void {
-  augur.connect({ ethereumNode: { http: network.http, ws: network.ws }, startBlockStreamOnConnect: false }, (): void => {
+  augur.connect({ ethereumNode: { http: getHttpUrl(network), ws: getWsUrl(network) }, startBlockStreamOnConnect: false }, (): void => {
     getNetworkID(db, augur, (err: Error|null, networkId: string|null) => {
       if (err) return callback(err);
       if (networkId == null) return callback(new Error("could not get networkId"));


### PR DESCRIPTION
https://github.com/AugurProject/augur-node/issues/293

Not like heroku, i could not find one button deployment support from DO.
Only 3rd party service, like https://installer.71m.us, supports deploy in DO with app.yml configuration.
Please check `https://github.com/kylewu/augur-node` and there is one `Install on DigitalOcean` button on top of README.

NOTE
===
installer.71m.us is HTTPS, when it checks our droplet status, it sends request through http to ip of the newly created droplet. This request will be blocked because of security reason (see browser console for detail). 
one solution is to deploy `installer.71m.us` yourself (check its page for detail)

Verification
===
curl  46.101.77.91:9001
Hello World

`46.101.77.91` is my droplet