### PR TITLE
serialize token balance updates, to and from might be the same, and y…

### DIFF
--- a/src/blockchain/log-processors/tokens-transferred.ts
+++ b/src/blockchain/log-processors/tokens-transferred.ts
@@ -1,6 +1,6 @@
 import Augur from "augur.js";
 import * as Knex from "knex";
-import { parallel } from "async";
+import { series } from "async";
 import { BigNumber } from "bignumber.js";
 import { FormattedEventLog, ErrorCallback, AsyncCallback } from "../../types";
 import { augurEmitter } from "../../events";
@@ -24,7 +24,7 @@ export function processTokensTransferredLog(db: Knex, augur: Augur, log: Formatt
   db.insert(tokenTransferDataToInsert).into("transfers").asCallback((err: Error|null): void => {
     if (err) return callback(err);
     augurEmitter.emit("TokensTransferred", Object.assign({}, log, tokenTransferDataToInsert));
-    parallel([
+    series([
       (next: AsyncCallback): void => increaseTokenBalance(db, augur, token, log.to, value, next),
       (next: AsyncCallback): void => decreaseTokenBalance(db, augur, token, log.from, value, next),
     ], (err: Error|null): void => {
@@ -40,7 +40,7 @@ export function processTokensTransferredLogRemoval(db: Knex, augur: Augur, log: 
     augurEmitter.emit("TokensTransferred", log);
     const token = log.token || log.address;
     const value = new BigNumber(log.value || log.amount, 10);
-    parallel([
+    series([
       (next: AsyncCallback): void => increaseTokenBalance(db, augur, token, log.from, value, next),
       (next: AsyncCallback): void => decreaseTokenBalance(db, augur, token, log.to, value, next),
     ], (err: Error|null): void => {


### PR DESCRIPTION
…ou're competing for the same rows, and not using a transaction internally