### PR TITLE
take universe as part of the initial reporters request

### DIFF
--- a/src/server/dispatch-json-rpc-request.ts
+++ b/src/server/dispatch-json-rpc-request.ts
@@ -65,7 +65,7 @@ export function dispatchJsonRpcRequest(db: Knex, request: JsonRpcRequest, augur:
     case "getDisputeInfo":
       return getDisputeInfo(db, request.params.marketIds, request.params.account, callback);
     case "getInitialReporters":
-      return getInitialReporters(db, augur, request.params.reporter, request.params.redeemed, request.params.withRepBalance, callback);
+      return getInitialReporters(db, augur, request.params.universe, request.params.reporter, request.params.redeemed, request.params.withRepBalance, callback);
     case "getReportingFees":
       return getReportingFees(db, augur, request.params.reporter, request.params.universe, request.params.feeWindow, callback);
     case "getForkMigrationTotals":

--- a/src/server/getters/get-initial-reporters.ts
+++ b/src/server/getters/get-initial-reporters.ts
@@ -4,14 +4,13 @@ import { Address } from "../../types";
 import { formatBigNumberAsFixed } from "../../utils/format-big-number-as-fixed";
 import { InitialReportersRow, UIInitialReporters } from "../../types";
 
-export function getInitialReporters(db: Knex, augur: Augur, reporter: Address, redeemed: boolean|null|undefined, withRepBalance: boolean|null|undefined, callback: (err: Error|null, result?: any) => void): void {
+export function getInitialReporters(db: Knex, augur: Augur, universe: Address, reporter: Address, redeemed: boolean|null|undefined, withRepBalance: boolean|null|undefined, callback: (err: Error|null, result?: any) => void): void {
   let query = db("initial_reports")
     .select(["marketID", "reporter", "amountStaked", "initialReporter", "redeemed", "isDesignatedReporter", "balances.balance AS repBalance"])
     .join("balances", "balances.owner", "=", "initial_reports.initialReporter")
-    .where({
-      reporter,
-      "balances.token": augur.contracts.addresses[augur.rpc.getNetworkID()].ReputationToken,
-    });
+    .join("universes", "universes.universe", db.raw("?", universe))
+    .where({reporter})
+    .where("balances.token", db.raw("universes.reputationToken"));
 
   if (withRepBalance) query = query.where("repBalance", ">", "0");
   if (redeemed != null) query = query.where({ redeemed });

--- a/src/server/getters/get-initial-reporters.ts
+++ b/src/server/getters/get-initial-reporters.ts
@@ -8,9 +8,9 @@ export function getInitialReporters(db: Knex, augur: Augur, universe: Address, r
   let query = db("initial_reports")
     .select(["marketID", "reporter", "amountStaked", "initialReporter", "redeemed", "isDesignatedReporter", "balances.balance AS repBalance"])
     .join("balances", "balances.owner", "=", "initial_reports.initialReporter")
-    .join("universes", "universes.universe", db.raw("?", universe))
+    .join("universes", "universes.reputationToken", "balances.token")
     .where({reporter})
-    .where("balances.token", db.raw("universes.reputationToken"));
+    .where("universes.universe", universe);
 
   if (withRepBalance) query = query.where("repBalance", ">", "0");
   if (redeemed != null) query = query.where({ redeemed });

--- a/test/server/getters/get-initial-reporters.js
+++ b/test/server/getters/get-initial-reporters.js
@@ -9,7 +9,7 @@ describe("server/getters/get-initial-reporters", () => {
     it(t.description, (done) => {
       setupTestDb((err, db) => {
         assert.isNull(err);
-        getInitialReporters(db, t.params.augur, t.params.reporter, t.params.redeemed, t.params.withRepBalance, (err, initialReporters) => {
+        getInitialReporters(db, t.params.augur, t.params.universe, t.params.reporter, t.params.redeemed, t.params.withRepBalance, (err, initialReporters) => {
           t.assertions(err, initialReporters);
           done();
         });
@@ -19,20 +19,7 @@ describe("server/getters/get-initial-reporters", () => {
   test({
     description: "get the initial reporter contracts owned by this reporter",
     params: {
-      augur: {
-        rpc: {
-          getNetworkID: () => {
-            return 1;
-          },
-        },
-        contracts: {
-          addresses: {
-            1: {
-              ReputationToken: "REP_TOKEN",
-            },
-          },
-        },
-      },
+      universe: "0x000000000000000000000000000000000000000b",
       reporter: "0x0000000000000000000000000000000000000b0b",
     },
     assertions: (err, initialReporters) => {


### PR DESCRIPTION
It was trying to get a REP contract address from the ether and was never working probably. Now it takes a universe and gets the rep contract associated with it.