### PR TITLE
add "needsDisavowal" for markets and make "disavowed" account for cases

### DIFF
--- a/src/blockchain/log-processors/crowdsourcer.ts
+++ b/src/blockchain/log-processors/crowdsourcer.ts
@@ -70,6 +70,7 @@ export function processDisputeCrowdsourcerCreatedLog(db: Knex, augur: Augur, log
           size: log.size,
           payoutId,
           completed: null,
+          disavowed: 0,
         };
         db.insert(crowdsourcerToInsert).into("crowdsourcers").asCallback((err: Error|null): void => {
           if (err) return callback(err);

--- a/src/blockchain/log-processors/index.ts
+++ b/src/blockchain/log-processors/index.ts
@@ -27,6 +27,7 @@ import { processInitialReporterTransferredLog, processInitialReporterTransferred
 import { processMarketMigratedLog, processMarketMigratedLogRemoval } from "./market-migrated";
 import { processReportingParticipantDisavowedLog, processReportingParticipantDisavowedLogRemoval } from "./reporting-participant-disavowed";
 import { processMarketMailboxTransferredLog, processMarketMailboxTransferredLogRemoval } from "./market-mailbox-transferred";
+import { processMarketParticipantsDisavowedLog, processMarketParticipantsDisavowedLogRemoval } from "./market-participants-disavowed";
 
 function noop(db: Knex, augur: Augur, log: FormattedEventLog, callback: ErrorCallback) {
   callback(null);
@@ -166,7 +167,10 @@ export const logProcessors: LogProcessors = {
       add: processCompleteSetsPurchasedOrSoldLog,
       remove: processCompleteSetsPurchasedOrSoldLogRemoval,
     },
-    MarketParticipantsDisavowed: passThroughLog,
+    MarketParticipantsDisavowed: {
+      add: processMarketParticipantsDisavowedLog,
+      remove: processMarketParticipantsDisavowedLogRemoval,
+    },
   },
   LegacyReputationToken: {
     Transfer: {

--- a/src/blockchain/log-processors/market-created.ts
+++ b/src/blockchain/log-processors/market-created.ts
@@ -74,6 +74,7 @@ export function processMarketCreatedLog(db: Knex, augur: Augur, log: FormattedEv
           sharesOutstanding:          "0",
           forking:                    0,
           needsMigration:             0,
+          needsDisavowal:             0,
           finalizationBlockNumber:    null,
         };
         const outcomesDataToInsert: Partial<OutcomesRow<string>> = formatBigNumberAsFixed<Partial<OutcomesRow<BigNumber>>, Partial<OutcomesRow<string>>>({

--- a/src/blockchain/log-processors/market-migrated.ts
+++ b/src/blockchain/log-processors/market-migrated.ts
@@ -3,9 +3,27 @@ import * as Knex from "knex";
 import { FormattedEventLog, ErrorCallback } from "../../types";
 
 export function processMarketMigratedLog(db: Knex, augur: Augur, log: FormattedEventLog, callback: ErrorCallback): void {
-  db.update({ universe: log.newUniverse, needsMigration: db.raw("needsMigration - 1") }).into("markets").where("marketId", log.market).asCallback(callback);
+  db.update({
+    universe: log.newUniverse,
+    needsMigration: db.raw("needsMigration - 1"),
+    needsDisavowal: db.raw("needsDisavowal - 1"),
+  }).into("markets").where("marketId", log.market).asCallback((err) => {
+    if (err) return callback(err);
+    db.update({
+      disavowed: db.raw("disavowed + 1"),
+    }).into("crowdsourcers").where("marketId", log.market).asCallback(callback);
+  });
 }
 
 export function processMarketMigratedLogRemoval(db: Knex, augur: Augur, log: FormattedEventLog, callback: ErrorCallback): void {
-  db.update({ universe: log.originalUniverse, needsMigration: db.raw("needsMigration + 1") }).into("markets").where("marketId", log.market).asCallback(callback);
+  db.update({
+    universe: log.originalUniverse,
+    needsMigration: db.raw("needsMigration + 1"),
+    needsDisavowal: db.raw("needsDisavowal + 1"),
+  }).into("markets").where("marketId", log.market).asCallback((err) => {
+    if (err) return callback(err);
+    db.update({
+      disavowed: db.raw("disavowed - 1"),
+    }).into("crowdsourcers").where("marketId", log.market).asCallback(callback);
+  });
 }

--- a/src/blockchain/log-processors/market-participants-disavowed.ts
+++ b/src/blockchain/log-processors/market-participants-disavowed.ts
@@ -3,9 +3,19 @@ import * as Knex from "knex";
 import { FormattedEventLog, ErrorCallback } from "../../types";
 
 export function processMarketParticipantsDisavowedLog(db: Knex, augur: Augur, log: FormattedEventLog, callback: ErrorCallback): void {
-  db.from("crowdsourcers").where("marketId", log.market).update({ disavowed: db.raw("disavowed + 1")}).asCallback(callback);
+  db.update({
+    needsDisavowal: db.raw("needsDisavowal - 1"),
+  }).into("markets").where("marketId", log.market).asCallback((err) => {
+    if (err) return callback(err);
+    db.from("crowdsourcers").where("marketId", log.market).update({ disavowed: db.raw("disavowed + 1")}).asCallback(callback);
+  });
 }
 
 export function processMarketParticipantsDisavowedLogRemoval(db: Knex, augur: Augur, log: FormattedEventLog, callback: ErrorCallback): void {
-  db.from("crowdsourcers").where("marketId", log.market).update({ disavowed: db.raw("disavowed - 1")}).asCallback(callback);
+  db.update({
+    needsDisavowal: db.raw("needsDisavowal + 1"),
+  }).into("markets").where("marketId", log.market).asCallback((err) => {
+    if (err) return callback(err);
+    db.from("crowdsourcers").where("marketId", log.market).update({ disavowed: db.raw("disavowed - 1")}).asCallback(callback);
+  });
 }

--- a/src/blockchain/log-processors/market-participants-disavowed.ts
+++ b/src/blockchain/log-processors/market-participants-disavowed.ts
@@ -1,0 +1,11 @@
+import Augur from "augur.js";
+import * as Knex from "knex";
+import { FormattedEventLog, ErrorCallback } from "../../types";
+
+export function processMarketParticipantsDisavowedLog(db: Knex, augur: Augur, log: FormattedEventLog, callback: ErrorCallback): void {
+  db.from("crowdsourcers").where("marketId", log.market).update({ disavowed: db.raw("disavowed + 1")}).asCallback(callback);
+}
+
+export function processMarketParticipantsDisavowedLogRemoval(db: Knex, augur: Augur, log: FormattedEventLog, callback: ErrorCallback): void {
+  db.from("crowdsourcers").where("marketId", log.market).update({ disavowed: db.raw("disavowed - 1")}).asCallback(callback);
+}

--- a/src/migrations/20171005123235_markets.ts
+++ b/src/migrations/20171005123235_markets.ts
@@ -38,7 +38,8 @@ exports.up = async (knex: Knex): Promise<any> => {
       "numTicks" varchar(255) NOT NULL CONSTRAINT "nonnegativeNumTicks" CHECK (ltrim("numTicks", '-') = "numTicks"),
       "consensusPayoutId" integer,
       "disputeRounds" integer,
-      "isInvalid" boolean
+      "isInvalid" boolean,
+      "needsDisavowal" boolean DEFAULT 0
     )`)
     .raw("CREATE INDEX endTime ON markets (endTime)");
   });

--- a/src/migrations/20180122152117_crowdsourcers.ts
+++ b/src/migrations/20180122152117_crowdsourcers.ts
@@ -16,7 +16,7 @@ exports.up = async (knex: Knex): Promise<any> => {
       table.string("size", 255);
       table.string("amountStaked", 255).defaultTo("0").notNullable();
       table.integer("completed").nullable();
-      table.integer("disavowed").defaultTo(0);
+      table.boolean("disavowed").defaultTo(0).notNullable();
 
       table.index(["marketId"]);
     });

--- a/src/seeds/test/crowdsourcer.ts
+++ b/src/seeds/test/crowdsourcer.ts
@@ -15,6 +15,7 @@ exports.seed = async (knex: Knex): Promise<any> => {
       transactionHash: "0x0000000000000000000000000000000000000000000000000000000000000E00",
       logIndex: 0,
       completed: 1,
+      disavowed: 0,
     }, {
       crowdsourcerId: "0x0000000000000000001000000000000000000002",
       marketId: "0x0000000000000000000000000000000000000011",
@@ -26,6 +27,7 @@ exports.seed = async (knex: Knex): Promise<any> => {
       completed: 1,
       transactionHash: "0x0000000000000000000000000000000000000000000000000000000000000E01",
       logIndex: 0,
+      disavowed: 0,
     }, {
       crowdsourcerId: "0x0000000000000000001000000000000000000005",
       marketId: "0x0000000000000000000000000000000000000011",
@@ -36,6 +38,7 @@ exports.seed = async (knex: Knex): Promise<any> => {
       blockNumber: 1400102,
       transactionHash: "0x0000000000000000000000000000000000000000000000000000000000000E01",
       logIndex: 0,
+      disavowed: 0,
     }, {
       crowdsourcerId: "0x0000000000000000001000000000000000000003",
       marketId: "0x0000000000000000000000000000000000000019",
@@ -46,6 +49,7 @@ exports.seed = async (knex: Knex): Promise<any> => {
       blockNumber: 1400102,
       transactionHash: "0x0000000000000000000000000000000000000000000000000000000000000E01",
       logIndex: 1,
+      disavowed: 0,
     },  {
       crowdsourcerId: "0x0000000000000000001000000000000000000004",
       marketId: "0x0000000000000000000000000000000000000211",
@@ -56,6 +60,7 @@ exports.seed = async (knex: Knex): Promise<any> => {
       blockNumber: 1500002,
       transactionHash: "0x0000000000000000000000000000000000000000000000000000000000000F01",
       logIndex: 1,
+      disavowed: 0,
     },  {
       crowdsourcerId: "0x0000000000000000001000000000000000000006",
       marketId: "0x00000000000000000000000000000000000000f1",
@@ -66,6 +71,7 @@ exports.seed = async (knex: Knex): Promise<any> => {
       blockNumber: 1500002,
       transactionHash: "0x0000000000000000000000000000000000000000000000000000000000000F01",
       logIndex: 1,
+      disavowed: 0,
     },  {
       crowdsourcerId: "0x0000000000000000001000000000000000000007",
       marketId: "0x00000000000000000000000000000000000000f1",

--- a/src/seeds/test/markets.ts
+++ b/src/seeds/test/markets.ts
@@ -33,6 +33,7 @@ exports.seed = async (knex: Knex): Promise<any> => {
       numTicks: 10000,
       forking: 0,
       needsMigration: 0,
+      needsDisavowal: 0,
     }, {
       marketId: "0x0000000000000000000000000000000000000002",
       universe: "0x000000000000000000000000000000000000000b",
@@ -62,6 +63,7 @@ exports.seed = async (knex: Knex): Promise<any> => {
       numTicks: 10000,
       forking: 0,
       needsMigration: 0,
+      needsDisavowal: 0,
     }, {
       marketId: "0x0000000000000000000000000000000000000003",
       universe: "0x000000000000000000000000000000000000000b",
@@ -91,6 +93,7 @@ exports.seed = async (knex: Knex): Promise<any> => {
       numTicks: 10000,
       forking: 0,
       needsMigration: 0,
+      needsDisavowal: 0,
     }, {
       marketId: "0x0000000000000000000000000000000000000011",
       universe: "0x000000000000000000000000000000000000000b",
@@ -120,6 +123,7 @@ exports.seed = async (knex: Knex): Promise<any> => {
       numTicks: 10000,
       forking: 0,
       needsMigration: 0,
+      needsDisavowal: 0,
     }, {
       marketId: "0x0000000000000000000000000000000000000012",
       universe: "0x000000000000000000000000000000000000000b",
@@ -149,6 +153,7 @@ exports.seed = async (knex: Knex): Promise<any> => {
       numTicks: 10000,
       forking: 0,
       needsMigration: 0,
+      needsDisavowal: 0,
     }, {
       marketId: "0x0000000000000000000000000000000000000013",
       universe: "0x000000000000000000000000000000000000000b",
@@ -178,6 +183,7 @@ exports.seed = async (knex: Knex): Promise<any> => {
       numTicks: 10000,
       forking: 0,
       needsMigration: 0,
+      needsDisavowal: 0,
     }, {
       marketId: "0x0000000000000000000000000000000000000014",
       universe: "0x000000000000000000000000000000000000000b",
@@ -207,6 +213,7 @@ exports.seed = async (knex: Knex): Promise<any> => {
       numTicks: 10000,
       forking: 0,
       needsMigration: 0,
+      needsDisavowal: 0,
     }, {
       marketId: "0x0000000000000000000000000000000000000015",
       universe: "0x000000000000000000000000000000000000000b",
@@ -236,6 +243,7 @@ exports.seed = async (knex: Knex): Promise<any> => {
       numTicks: 10000,
       forking: 0,
       needsMigration: 0,
+      needsDisavowal: 0,
     }, {
       marketId: "0x0000000000000000000000000000000000000016",
       universe: "0x000000000000000000000000000000000000000b",
@@ -265,6 +273,7 @@ exports.seed = async (knex: Knex): Promise<any> => {
       numTicks: 949,
       forking: 0,
       needsMigration: 0,
+      needsDisavowal: 0,
     }, {
       marketId: "0x0000000000000000000000000000000000000017",
       universe: "0x000000000000000000000000000000000000000b",
@@ -294,6 +303,7 @@ exports.seed = async (knex: Knex): Promise<any> => {
       numTicks: 10003,
       forking: 0,
       needsMigration: 0,
+      needsDisavowal: 0,
     }, {
       marketId: "0x0000000000000000000000000000000000000018",
       universe: "0x000000000000000000000000000000000000000b",
@@ -323,6 +333,7 @@ exports.seed = async (knex: Knex): Promise<any> => {
       numTicks: 10003,
       forking: 0,
       needsMigration: 0,
+      needsDisavowal: 0,
     }, {
       marketId: "0x0000000000000000000000000000000000000019",
       universe: "0x000000000000000000000000000000000000000b",
@@ -353,6 +364,7 @@ exports.seed = async (knex: Knex): Promise<any> => {
       numTicks: 10000,
       forking: 0,
       needsMigration: 0,
+      needsDisavowal: 0,
     }, {
       marketId: "0x0000000000000000000000000000000000000211",
       universe: "0x000000000000000000000000000000000000000b",
@@ -383,6 +395,7 @@ exports.seed = async (knex: Knex): Promise<any> => {
       initialReportSize: "10",
       forking: 0,
       needsMigration: 0,
+      needsDisavowal: 0,
     }, {
       marketId: "0x0000000000000000000000000000000000000222",
       universe: "0x000000000000000000000000000000000000000b",
@@ -412,6 +425,7 @@ exports.seed = async (knex: Knex): Promise<any> => {
       numTicks: 10000,
       forking: 0,
       needsMigration: 0,
+      needsDisavowal: 0,
     }, {
       marketId: "0x0000000000000000000000000000000000000233",
       universe: "CHILD_UNIVERSE",
@@ -441,6 +455,7 @@ exports.seed = async (knex: Knex): Promise<any> => {
       numTicks: 10000,
       forking: 0,
       needsMigration: 0,
+      needsDisavowal: 0,
     }, {
       marketId: "0x00000000000000000000000000000000000000f1",
       universe: "0x000000000000000000000000000000000000000b",
@@ -470,6 +485,7 @@ exports.seed = async (knex: Knex): Promise<any> => {
       numTicks: 10000,
       forking: 1,
       needsMigration: 0,
+      needsDisavowal: 0,
     }];
     return knex.batchInsert("markets", seedData, seedData.length);
   });

--- a/src/types.ts
+++ b/src/types.ts
@@ -175,6 +175,7 @@ export interface MarketsRow<BigNumberType> {
   isInvalid?: boolean|null;
   forking: number;
   needsMigration: number;
+  needsDisavowal: number;
 }
 
 export interface PositionsRow<BigNumberType> {

--- a/test/blockchain/log-processors/crowdsourcers.js
+++ b/test/blockchain/log-processors/crowdsourcers.js
@@ -175,6 +175,7 @@ describe("blockchain/log-processors/crowdsourcers", () => {
           finalizationBlockNumber: null,
           forking: 0,
           needsMigration: 0,
+          needsDisavowal: 0,
           initialReportSize: new BigNumber("10", 10),
           isInvalid: null,
           longDescription: null,
@@ -253,6 +254,7 @@ describe("blockchain/log-processors/crowdsourcers", () => {
           creationTime: 1509065474,
           forking: 0,
           needsMigration: 0,
+          needsDisavowal: 0,
         });
       },
     },

--- a/test/blockchain/log-processors/market-created.js
+++ b/test/blockchain/log-processors/market-created.js
@@ -150,6 +150,7 @@ describe("blockchain/log-processors/market-created", () => {
             isInvalid: null,
             forking: 0,
             needsMigration: 0,
+            needsDisavowal: 0,
           }],
           categories: [{
             category: "TEST_CATEGORY",
@@ -310,6 +311,7 @@ describe("blockchain/log-processors/market-created", () => {
             isInvalid: null,
             forking: 0,
             needsMigration: 0,
+            needsDisavowal: 0,
           }],
           categories: [{
             category: "TEST_CATEGORY",
@@ -491,6 +493,7 @@ describe("blockchain/log-processors/market-created", () => {
             isInvalid: null,
             forking: 0,
             needsMigration: 0,
+            needsDisavowal: 0,
           }],
           categories: [{
             category: "TEST_CATEGORY",
@@ -646,6 +649,7 @@ describe("blockchain/log-processors/market-created", () => {
             isInvalid: null,
             forking: 0,
             needsMigration: 0,
+            needsDisavowal: 0,
           }],
           categories: [{
             category: "TEST_CATEGORY",

--- a/test/blockchain/log-processors/market-migrated.js
+++ b/test/blockchain/log-processors/market-migrated.js
@@ -5,7 +5,7 @@ const setupTestDb = require("../../test.database");
 const {processMarketMigratedLog, processMarketMigratedLogRemoval} = require("../../../build/blockchain/log-processors/market-migrated");
 
 const getMarket = (db, params, callback) => {
-  db.select(["markets.marketId", "markets.universe", "markets.needsMigration"]).from("markets").where({"markets.marketId": params.log.market}).asCallback(callback);
+  db.select(["markets.marketId", "markets.universe", "markets.needsMigration", "markets.needsDisavowal"]).from("markets").where({"markets.marketId": params.log.market}).asCallback(callback);
 };
 
 describe("blockchain/log-processors/market-migrated", () => {
@@ -15,16 +15,18 @@ describe("blockchain/log-processors/market-migrated", () => {
         assert.isNull(err);
         db.transaction((trx) => {
           trx("markets").update("needsMigration", 1).where("marketId", t.params.log.market).asCallback((err) => {
-            assert.isNull(err);
-            processMarketMigratedLog(trx, t.params.augur, t.params.log, (err) => {
+            trx("markets").update("needsDisavowal", 1).where("marketId", t.params.log.market).asCallback((err) => {
               assert.isNull(err);
-              getMarket(trx, t.params, (err, marketRow) => {
-                t.assertions.onAdded(err, marketRow);
-                processMarketMigratedLogRemoval(trx, t.params.augur, t.params.log, (err) => {
-                  assert.isNull(err);
-                  getMarket(trx, t.params, (err, marketRow) => {
-                    t.assertions.onRemoved(err, marketRow);
-                    done();
+              processMarketMigratedLog(trx, t.params.augur, t.params.log, (err) => {
+                assert.isNull(err);
+                getMarket(trx, t.params, (err, marketRow) => {
+                  t.assertions.onAdded(err, marketRow);
+                  processMarketMigratedLogRemoval(trx, t.params.augur, t.params.log, (err) => {
+                    assert.isNull(err);
+                    getMarket(trx, t.params, (err, marketRow) => {
+                      t.assertions.onRemoved(err, marketRow);
+                      done();
+                    });
                   });
                 });
               });
@@ -54,6 +56,7 @@ describe("blockchain/log-processors/market-migrated", () => {
             "marketId": "0x0000000000000000000000000000000000000211",
             "universe": "NEW_UNIVERSE",
             "needsMigration": 0,
+            "needsDisavowal": 0,
           },
         ]);
       },
@@ -64,6 +67,7 @@ describe("blockchain/log-processors/market-migrated", () => {
             "marketId": "0x0000000000000000000000000000000000000211",
             "universe": "ORIGINAL_UNIVERSE",
             "needsMigration": 1,
+            "needsDisavowal": 1,
           },
         ]);
       },

--- a/test/blockchain/log-processors/market-participants-disavowed.js
+++ b/test/blockchain/log-processors/market-participants-disavowed.js
@@ -1,0 +1,55 @@
+"use strict";
+
+const assert = require("chai").assert;
+const setupTestDb = require("../../test.database");
+const { processMarketParticipantsDisavowedLog, processMarketParticipantsDisavowedLogRemoval } = require("../../../build/blockchain/log-processors/market-participants-disavowed");
+
+describe("blockchain/log-processors/market-participants-disavowed", () => {
+  const test = (t) => {
+    const getMarketCrowdsourcers = (db, params, callback) => db("crowdsourcers").where({ marketId: params.log.market }).asCallback(callback);
+    it(t.description, (done) => {
+      setupTestDb((err, db) => {
+        assert.isNull(err);
+        db.transaction((trx) => {
+          processMarketParticipantsDisavowedLog(trx, t.params.augur, t.params.log, (err) => {
+            assert.isNull(err);
+            getMarketCrowdsourcers(trx, t.params, (err, records) => {
+              t.assertions.onAdded(err, records);
+              processMarketParticipantsDisavowedLogRemoval(trx, t.params.augur, t.params.log, (err) => {
+                assert.isNull(err);
+                getMarketCrowdsourcers(trx, t.params, (err, records) => {
+                  t.assertions.onRemoved(err, records);
+                  done();
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+  };
+  test({
+    description: "Market Participants Disavowed",
+    params: {
+      log: {
+        market: "0x0000000000000000000000000000000000000011",
+      },
+    },
+    assertions: {
+      onAdded: (err, records) => {
+        assert.isNull(err);
+        assert.equal(records.length, 3);
+        assert.equal(records[0].disavowed, 1);
+        assert.equal(records[1].disavowed, 1);
+        assert.equal(records[2].disavowed, 1);
+      },
+      onRemoved: (err, records) => {
+        assert.isNull(err);
+        assert.equal(records.length, 3);
+        assert.equal(records[0].disavowed, 0);
+        assert.equal(records[1].disavowed, 0);
+        assert.equal(records[2].disavowed, 0);
+      },
+    },
+  });
+});

--- a/test/blockchain/log-processors/universe-forked.js
+++ b/test/blockchain/log-processors/universe-forked.js
@@ -6,7 +6,9 @@ const { processUniverseForkedLog, processUniverseForkedLogRemoval } = require(".
 
 describe("blockchain/log-processors/universe-forked", () => {
   const test = (t) => {
+    const otherMarket = "0x0000000000000000000000000000000000000222";
     const getForkingMarket = (db, params, callback) => db("markets").where({ universe: params.log.universe, forking: 1 }).asCallback(callback);
+    const getOtherMarket = (db, params, callback) => db("markets").where({ marketId: otherMarket }).asCallback(callback);
     it(t.description, (done) => {
       setupTestDb((err, db) => {
         assert.isNull(err);
@@ -15,11 +17,17 @@ describe("blockchain/log-processors/universe-forked", () => {
             assert.isNull(err);
             getForkingMarket(trx, t.params, (err, records) => {
               t.assertions.onAdded(err, records);
-              processUniverseForkedLogRemoval(trx, t.params.augur, t.params.log, (err) => {
-                assert.isNull(err);
-                getForkingMarket(trx, t.params, (err, records) => {
-                  t.assertions.onRemoved(err, records);
-                  done();
+              getOtherMarket(trx, t.params, (err, records) => {
+                t.assertions.otherMarketOnAdded(err, records);
+                processUniverseForkedLogRemoval(trx, t.params.augur, t.params.log, (err) => {
+                  assert.isNull(err);
+                  getForkingMarket(trx, t.params, (err, records) => {
+                    t.assertions.onRemoved(err, records);
+                    getOtherMarket(trx, t.params, (err, records) => {
+                      t.assertions.otherMarketOnRemoved(err, records);
+                      done();
+                    });
+                  });
                 });
               });
             });
@@ -57,9 +65,15 @@ describe("blockchain/log-processors/universe-forked", () => {
         assert.equal(records[1].marketId, "0x00000000000000000000000000000000000000f1");
         assert.equal(records[1].forking, 1);
       },
+      otherMarketOnAdded: (err, records) => {
+        assert.equal(records[0].needsDisavowal, 1);
+      },
       onRemoved: (err, records) => {
         assert.isNull(err);
         assert.equal(records.length, 1);
+      },
+      otherMarketOnRemoved: (err, records) => {
+        assert.equal(records[0].needsDisavowal, 0);
       },
     },
   });


### PR DESCRIPTION
As discussed in Discord I didn't make `disavowed` an enum and instead kept it as boolean since the one case we needed that implicitly has the state of "needs disavowal" (forked market + not disavowed).

I added `needsDisavowal` for markets in a forking universe that haven't been migrated or disavowed.

Migration and manual disavowal will now mark all the market's crowdsourcers as disavowed as well.