### PR TITLE
fixes for various get reporting fees issues

### DIFF
--- a/src/server/getters/get-reporting-fees.ts
+++ b/src/server/getters/get-reporting-fees.ts
@@ -78,6 +78,8 @@ interface FeeWindowCompletionStakeRow {
   feeWindow: Address;
   amountStaked: BigNumber;
   winning: number;
+  disavowed: boolean;
+  completed: boolean;
   forking: boolean;
   marketId: Address;
 }
@@ -142,7 +144,7 @@ interface ParticipationTokenEthFee extends FeeWindowEthFee {
   participationTokens: BigNumber;
 }
 
-interface MarketsDisputedMap {
+interface AddressMap {
   [marketId: string]: boolean;
 }
 
@@ -246,11 +248,12 @@ function getMarketsReportingParticipants(db: Knex, reporter: Address, universe: 
 }
 
 function getStakedRepResults(db: Knex, reporter: Address, universe: Address, callback: (err: Error|null, result?: { fees: RepStakeResults }) => void) {
-  const crowdsourcerQuery = db.select(["fee_windows.feeWindow", "stakedRep.balance as amountStaked", "payouts.winning", "markets.forking", "markets.marketId"]).from("fee_windows");
+  const crowdsourcerQuery = db.select(["fee_windows.feeWindow", "stakedRep.balance as amountStaked", "payouts.winning", "crowdsourcers.disavowed", "crowdsourcers.completed", "markets.forking", "markets.marketId"]).from("fee_windows");
   crowdsourcerQuery.join("crowdsourcers", "crowdsourcers.feeWindow", "fee_windows.feeWindow");
   crowdsourcerQuery.join("payouts", "crowdsourcers.payoutId", "payouts.payoutId");
   crowdsourcerQuery.join("markets", "markets.marketId", "crowdsourcers.marketId");
-  crowdsourcerQuery.where(db.raw("(payouts.winning or markets.forking)"));
+  crowdsourcerQuery.join("market_state", "markets.marketStateId", "market_state.marketStateId");
+  crowdsourcerQuery.where(db.raw("(markets.forking or crowdsourcers.disavowed or market_state.reportingState IN (?, ?))", [ReportingState.AWAITING_FINALIZATION, ReportingState.FINALIZED]));
   crowdsourcerQuery.leftJoin("balances AS stakedRep", function () {
     this
       .on("crowdsourcers.crowdsourcerId", db.raw("stakedRep.token"))
@@ -261,8 +264,9 @@ function getStakedRepResults(db: Knex, reporter: Address, universe: Address, cal
   const initialReportersQuery = db.select(["initial_reports.amountStaked", "payouts.winning", "markets.forking", "markets.marketId"]).from("initial_reports")
     .join("payouts", "initial_reports.payoutId", "payouts.payoutId")
     .join("markets", "markets.marketId", "initial_reports.marketId")
+    .join("market_state", "markets.marketStateId", "market_state.marketStateId")
     .where("markets.universe", universe)
-    .where(db.raw("(payouts.winning or markets.forking)"))
+    .where(db.raw("(markets.forking or initial_reports.disavowed or market_state.reportingState IN (?, ?))", [ReportingState.AWAITING_FINALIZATION, ReportingState.FINALIZED]))
     .where("initial_reports.reporter", reporter)
     .whereNot("initial_reports.redeemed", 1);
 
@@ -272,14 +276,17 @@ function getStakedRepResults(db: Knex, reporter: Address, universe: Address, cal
   }, (err: Error|null, result: StakedRepResults) => {
     if (err) return callback(err);
 
-    const marketDisputed: MarketsDisputedMap = {};
+    const marketDisputed: AddressMap = {};
 
     let fees = _.reduce(result.crowdsourcers, (acc: RepStakeResults, feeWindowCompletionStake: FeeWindowCompletionStakeRow) => {
       marketDisputed[feeWindowCompletionStake.marketId] = true;
+      const getsRep = feeWindowCompletionStake.winning || feeWindowCompletionStake.disavowed || !feeWindowCompletionStake.completed;
+      const earnsRep = feeWindowCompletionStake.completed && (feeWindowCompletionStake.winning > 0);
+      const lostRep = feeWindowCompletionStake.completed && (feeWindowCompletionStake.winning === 0);
       return {
-        unclaimedRepStaked: acc.unclaimedRepStaked.plus(feeWindowCompletionStake.forking ? ZERO : (feeWindowCompletionStake.winning === 0 ? ZERO : (feeWindowCompletionStake.amountStaked || ZERO))),
-        unclaimedRepEarned: acc.unclaimedRepEarned.plus(feeWindowCompletionStake.forking ? ZERO : (feeWindowCompletionStake.winning === 0 ? ZERO : (feeWindowCompletionStake.amountStaked || ZERO)).div(2)),
-        lostRep: acc.lostRep.plus(feeWindowCompletionStake.winning === 0 ? (feeWindowCompletionStake.amountStaked || ZERO) : ZERO),
+        unclaimedRepStaked: acc.unclaimedRepStaked.plus(feeWindowCompletionStake.forking ? ZERO : (!getsRep ? ZERO : (feeWindowCompletionStake.amountStaked || ZERO))),
+        unclaimedRepEarned: acc.unclaimedRepEarned.plus(feeWindowCompletionStake.forking ? ZERO : (!earnsRep ? ZERO : (feeWindowCompletionStake.amountStaked || ZERO)).div(2)),
+        lostRep: acc.lostRep.plus(lostRep ? (feeWindowCompletionStake.amountStaked || ZERO) : ZERO),
         unclaimedForkRepStaked: acc.unclaimedForkRepStaked.plus(feeWindowCompletionStake.forking ? (feeWindowCompletionStake.amountStaked || ZERO) : ZERO),
       };
     }, { unclaimedRepStaked: ZERO, unclaimedRepEarned: ZERO, lostRep: ZERO, unclaimedForkRepStaked: ZERO });
@@ -357,7 +364,11 @@ function getParticipantEthFees(db: Knex, augur: Augur, reporter: Address, univer
     db.raw("IFNULL(cashParticipant.balance,0) as cashParticipant"),
     db.raw("IFNULL(participationTokenSupply.supply,0) as participationTokenSupply"),
     "disavowed"]).from("all_participants");
-  participantQuery.leftJoin("balances as feeToken", "feeToken.owner", "all_participants.participantAddress");
+  participantQuery.leftJoin("balances as feeToken", function () {
+    this
+      .on("feeToken.owner", db.raw("all_participants.participantAddress"))
+      .andOn("feeToken.token", "!=", db.raw("?", augur.contracts.addresses[augur.rpc.getNetworkID()].Cash));
+  });
   participantQuery.leftJoin("fee_windows", "fee_windows.feeToken", "feeToken.token");
   participantQuery.leftJoin("balances AS cashFeeWindow", function () {
     this
@@ -406,7 +417,7 @@ export function getReportingFees(db: Knex, augur: Augur, reporter: Address|null,
         getStakedRepResults(db, reporter, universe, (err, repStakeResults) => {
           if (err || repStakeResults == null) return callback(err);
           getMarketsReportingParticipants(db, reporter, currentUniverse, (err, result: FormattedMarketInfo) => {
-            if (err || repStakeResults == null) return callback(err);
+            if (err || result == null) return callback(err);
             const unclaimedParticipantEthFees = _.reduce(participantEthFees, (acc, cur) => acc.plus(cur.fork ? 0 : cur.ethFees), ZERO);
             const unclaimedForkEthFees = _.reduce(participantEthFees, (acc, cur) => acc.plus(cur.fork ? cur.ethFees : 0), ZERO);
             const unclaimedParticipationTokenEthFees = _.reduce(participationTokenEthFees, (acc, cur) => acc.plus(cur.ethFees), ZERO);
@@ -419,7 +430,7 @@ export function getReportingFees(db: Knex, augur: Augur, reporter: Address|null,
                 unclaimedRepStaked: unclaimedRepStaked.toFixed(0, BigNumber.ROUND_DOWN),
                 unclaimedRepEarned: repStakeResults.fees.unclaimedRepEarned.toFixed(0, BigNumber.ROUND_DOWN),
                 lostRep: repStakeResults.fees.lostRep.toFixed(0, BigNumber.ROUND_DOWN),
-                unclaimedForkEth: unclaimedForkEthFees.plus(unclaimedParticipationTokenEthFees).toFixed(0, BigNumber.ROUND_DOWN),
+                unclaimedForkEth: unclaimedForkEthFees.toFixed(0, BigNumber.ROUND_DOWN),
                 unclaimedForkRepStaked: repStakeResults.fees.unclaimedForkRepStaked.toFixed(0, BigNumber.ROUND_DOWN),
               },
               feeWindows: redeemableFeeWindows.sort(),

--- a/test/server/getters/get-reporting-fees.js
+++ b/test/server/getters/get-reporting-fees.js
@@ -47,9 +47,9 @@ describe("server/getters/get-reporting-fees", () => {
       assert.deepEqual(marketsMatched, {
         total: {
           "unclaimedEth": "200",
-          "unclaimedRepEarned": "114",
-          "unclaimedRepStaked": "289",
-          "unclaimedForkEth": "200",
+          "unclaimedRepEarned": "0",
+          "unclaimedRepStaked": "391",
+          "unclaimedForkEth": "0",
           "unclaimedForkRepStaked": "331",
           "lostRep": "0",
         },


### PR DESCRIPTION
The two relevant ones that are actually fixed are:

https://app.clubhouse.io/augur/story/10864/getreportingfees-returns-unclaimedforkfees-after-rep-is-migrated

and

https://app.clubhouse.io/augur/story/10843/unmade-unfilled-dispute-bonds-can-t-be-reclaimed-by-disputer

This also partially addresses

https://app.clubhouse.io/augur/story/10842/unclaimedeth-has-incorrect-balance-for-initial-reporter-when-there-was-no-dispute

but leaves a lot to be done there (see CH comment)

