### PR TITLE
[AFTER augur-core -7] Get user trading history is returning too many share amounts

### DIFF
--- a/src/blockchain/log-processors/order-filled/index.ts
+++ b/src/blockchain/log-processors/order-filled/index.ts
@@ -42,13 +42,13 @@ export function processOrderFilledLog(db: Knex, augur: Augur, log: FormattedEven
         const orderCreator = ordersRow.orderCreator!;
         const price = ordersRow.fullPrecisionPrice!;
         const orderType = ordersRow.orderType!;
+        const amount = log.amount!;
         const numCreatorTokens = fixedPointToDecimal(new BigNumber(log.numCreatorTokens, 10), BN_WEI_PER_ETHER);
         const numCreatorShares = augur.utils.convertOnChainAmountToDisplayAmount(new BigNumber(log.numCreatorShares, 10), tickSize);
         const numFillerTokens = fixedPointToDecimal(new BigNumber(log.numFillerTokens, 10), BN_WEI_PER_ETHER);
         const numFillerShares = augur.utils.convertOnChainAmountToDisplayAmount(new BigNumber(log.numFillerShares, 10), tickSize);
         const marketCreatorFees = fixedPointToDecimal(new BigNumber(log.marketCreatorFees, 10), BN_WEI_PER_ETHER);
         const reporterFees = fixedPointToDecimal(new BigNumber(log.reporterFees, 10), BN_WEI_PER_ETHER);
-        const amount = calculateNumberOfSharesTraded(numCreatorShares, numCreatorTokens, calculateFillPrice(augur, price, minPrice, maxPrice, orderType));
         const tradeData = formatBigNumberAsFixed<TradesRow<BigNumber>, TradesRow<string>>({
           marketId,
           outcome,

--- a/test/blockchain/log-processors/order-filled/index.js
+++ b/test/blockchain/log-processors/order-filled/index.js
@@ -47,6 +47,7 @@ describe("blockchain/log-processors/order-filled", () => {
         shareToken: "0x1000000000000000000000000000000000000000",
         filler: "FILLER_ADDRESS",
         orderId: "0x1000000000000000000000000000000000000000000000000000000000000000",
+        amount: "1.42857142857142857143",
         numCreatorShares: "0",
         numCreatorTokens: fix("1", "string"),
         numFillerShares: augur.utils.convertDisplayAmountToOnChainAmount("2", "0.0001").toFixed(),
@@ -153,7 +154,7 @@ describe("blockchain/log-processors/order-filled", () => {
           marketCreatorFees: new BigNumber("0", 10),
           reporterFees: new BigNumber("0", 10),
           price: new BigNumber("0.7", 10),
-          amount: new BigNumber("3.33333333333333333333", 10),
+          amount: new BigNumber("1.42857142857142857143", 10),
           tradeGroupId: "TRADE_GROUP_ID",
         }]);
         assert.deepEqual(records.markets, {


### PR DESCRIPTION
Story details: https://app.clubhouse.io/augur/story/10359

After the new version