### PR TITLE
Weird Scalar Trading Bug

### DIFF
--- a/src/blockchain/log-processors/order-filled/refresh-position-in-market.ts
+++ b/src/blockchain/log-processors/order-filled/refresh-position-in-market.ts
@@ -12,14 +12,14 @@ export function refreshPositionInMarket(db: Knex, augur: Augur, marketId: Addres
     const minPrice = marketsRow.minPrice!;
     const maxPrice = marketsRow.maxPrice!;
     const numTicks = marketsRow.numTicks!;
-    const tickSize = numTicksToTickSize(numTicks, minPrice, maxPrice).toFixed();
+    const tickSize = numTicksToTickSize(numTicks, minPrice, maxPrice);
     augur.trading.getPositionInMarket({
       market: marketId,
       address: account,
-      tickSize,
+      tickSize: tickSize.toFixed(),
     }, (err: Error|null, positions: Array<string>): void => {
       if (err) return callback(err);
-      upsertPositionInMarket(db, augur, account, marketId, numTicks, positions, (err: Error|null) => {
+      upsertPositionInMarket(db, augur, account, marketId, minPrice, tickSize, positions, (err: Error|null) => {
         if (err) return callback(err);
         callback(err, positions);
       });

--- a/test/blockchain/log-processors/completesets.js
+++ b/test/blockchain/log-processors/completesets.js
@@ -50,6 +50,11 @@ describe("blockchain/log-processors/completesets", () => {
             },
           },
         },
+        utils: {
+          convertOnChainPriceToDisplayPrice: (onChainPrice, minDisplayPrice, tickSize) => {
+            return onChainPrice.times(tickSize).plus(minDisplayPrice);
+          },
+        },
         trading: {
           calculateProfitLoss: (p) => ({
             position: "2",

--- a/test/blockchain/log-processors/order-filled/index.js
+++ b/test/blockchain/log-processors/order-filled/index.js
@@ -109,6 +109,11 @@ describe("blockchain/log-processors/order-filled", () => {
           normalizePrice: p => p.price,
         },
       },
+      utils: {
+        convertOnChainPriceToDisplayPrice: (onChainPrice, minDisplayPrice, tickSize) => {
+          return onChainPrice.times(tickSize).plus(minDisplayPrice);
+        },
+      },
     },
     aux: {
       marketId: "0x0000000000000000000000000000000000000001",

--- a/test/blockchain/log-processors/tokens-transferred.js
+++ b/test/blockchain/log-processors/tokens-transferred.js
@@ -141,6 +141,11 @@ describe("blockchain/log-processors/tokens-transferred", () => {
           },
           normalizePrice: p => p.price,
         },
+        utils: {
+          convertOnChainPriceToDisplayPrice: (onChainPrice, minDisplayPrice, tickSize) => {
+            return onChainPrice.times(tickSize).plus(minDisplayPrice);
+          },
+        },
       },
     },
     assertions: {


### PR DESCRIPTION
Story details: https://app.clubhouse.io/augur/story/11255

In the volumetrics code -- we updated the price from the contracts and converted it from fixed-point to decimal. However, this conversion incorrectly ignored the scaling for scalar markets. The outcome was that the price on the `outcomes` table was incorrect.