### PR TITLE
Epheph/ch11260/handle states transitions for non forked

### DIFF
--- a/src/blockchain/log-processors/initial-report-submitted.ts
+++ b/src/blockchain/log-processors/initial-report-submitted.ts
@@ -9,7 +9,7 @@ export function processInitialReportSubmittedLog(db: Knex, augur: Augur, log: Fo
   db("universes").first("forked").where({ universe: log.universe }).asCallback((err, universeRow?: { forked: boolean }) => {
     if (err) return callback(err);
     if (universeRow == null) return callback(new Error("No universe in initial report"));
-    const marketState = universeRow.forked ? ReportingState.AWAITING_FORK_MIGRATION ? augur.constants.REPORTING_STATE.AWAITING_NEXT_WINDOW;
+    const marketState = universeRow.forked ? ReportingState.AWAITING_FORK_MIGRATION : augur.constants.REPORTING_STATE.AWAITING_NEXT_WINDOW;
     updateMarketState(db, log.market, log.blockNumber, marketState, (err: Error|null): void => {
       if (err) return callback(err);
       insertPayout(db, log.market, log.payoutNumerators, log.invalid, true, (err, payoutId) => {

--- a/src/blockchain/log-processors/initial-report-submitted.ts
+++ b/src/blockchain/log-processors/initial-report-submitted.ts
@@ -1,46 +1,51 @@
 import Augur from "augur.js";
 import * as Knex from "knex";
 import { parallel } from "async";
-import { FormattedEventLog, ErrorCallback, AsyncCallback, Address } from "../../types";
+import { FormattedEventLog, ErrorCallback, AsyncCallback, Address, ReportingState } from "../../types";
 import { updateMarketState, rollbackMarketState, insertPayout, updateMarketFeeWindow, updateDisputeRound, refreshMarketMailboxEthBalance } from "./database";
 import { augurEmitter } from "../../events";
 
 export function processInitialReportSubmittedLog(db: Knex, augur: Augur, log: FormattedEventLog, callback: ErrorCallback): void {
-  updateMarketState( db, log.market, log.blockNumber, augur.constants.REPORTING_STATE.AWAITING_NEXT_WINDOW, (err: Error|null): void => {
+  db("universes").first("forked").where({ universe: log.universe }).asCallback((err, universeRow?: { forked: boolean }) => {
     if (err) return callback(err);
-    insertPayout( db, log.market, log.payoutNumerators, log.invalid, true, (err, payoutId) => {
-      const reportToInsert = {
-        blockNumber: log.blockNumber,
-        transactionHash: log.transactionHash,
-        logIndex: log.logIndex,
-        marketId: log.market,
-        isDesignatedReporter: log.isDesignatedReporter,
-        reporter: log.reporter,
-        amountStaked: log.amountStaked,
-        payoutId,
-        redeemed: false,
-      };
-      parallel({
-        initialReport: (next: AsyncCallback) => {
-          augur.api.Market.getInitialReporter({ tx: { to: log.market }}, (err: Error|null, initialReporter?: Address): void => {
-            if (err) return next(err);
-            db.insert({ ...reportToInsert, initialReporter }).into("initial_reports").asCallback(next);
-          });
-        },
-        initialReportSizeUpdate: (next: AsyncCallback) => {
-          db("markets").update({initialReportSize: log.amountStaked}).where({marketId: log.market}).asCallback(next);
-        },
-        nextFeeWindow: (next: AsyncCallback) => {
-          updateMarketFeeWindow(db, augur, log.universe, log.market, true, next);
-        },
-        updateDisputeRound: (next: AsyncCallback) => {
-          updateDisputeRound(db, log.market, next);
-        },
-        refreshMarketMailboxEthBalance: (next: AsyncCallback) => refreshMarketMailboxEthBalance(db, augur, log.market, next),
-    }, (err: Error|null): void => {
-        if (err) return callback(err);
-        augurEmitter.emit("InitialReportSubmitted", log);
-        callback(null);
+    if (universeRow == null) return callback(new Error("No universe in initial report"));
+    const marketState = universeRow.forked ? ReportingState.AWAITING_FORK_MIGRATION ? augur.constants.REPORTING_STATE.AWAITING_NEXT_WINDOW;
+    updateMarketState(db, log.market, log.blockNumber, marketState, (err: Error|null): void => {
+      if (err) return callback(err);
+      insertPayout(db, log.market, log.payoutNumerators, log.invalid, true, (err, payoutId) => {
+        const reportToInsert = {
+          blockNumber: log.blockNumber,
+          transactionHash: log.transactionHash,
+          logIndex: log.logIndex,
+          marketId: log.market,
+          isDesignatedReporter: log.isDesignatedReporter,
+          reporter: log.reporter,
+          amountStaked: log.amountStaked,
+          payoutId,
+          redeemed: false,
+        };
+        parallel({
+          initialReport: (next: AsyncCallback) => {
+            augur.api.Market.getInitialReporter({ tx: { to: log.market } }, (err: Error|null, initialReporter?: Address): void => {
+              if (err) return next(err);
+              db.insert({ ...reportToInsert, initialReporter }).into("initial_reports").asCallback(next);
+            });
+          },
+          initialReportSizeUpdate: (next: AsyncCallback) => {
+            db("markets").update({ initialReportSize: log.amountStaked }).where({ marketId: log.market }).asCallback(next);
+          },
+          nextFeeWindow: (next: AsyncCallback) => {
+            updateMarketFeeWindow(db, augur, log.universe, log.market, true, next);
+          },
+          updateDisputeRound: (next: AsyncCallback) => {
+            updateDisputeRound(db, log.market, next);
+          },
+          refreshMarketMailboxEthBalance: (next: AsyncCallback) => refreshMarketMailboxEthBalance(db, augur, log.market, next),
+        }, (err: Error|null): void => {
+          if (err) return callback(err);
+          augurEmitter.emit("InitialReportSubmitted", log);
+          callback(null);
+        });
       });
     });
   });
@@ -52,11 +57,11 @@ export function processInitialReportSubmittedLogRemoval(db: Knex, augur: Augur, 
       marketState: (next: AsyncCallback) => {
         rollbackMarketState(db, log.market, augur.constants.REPORTING_STATE.AWAITING_NEXT_WINDOW, (err: Error|null) => {
           if (err) return callback(err);
-          db("initial_reports").delete().where({marketId: log.market}).asCallback(next);
+          db("initial_reports").delete().where({ marketId: log.market }).asCallback(next);
         });
       },
       initialReportSize: (next: AsyncCallback) => {
-        db("markets").update({initialReportSize: null}).where({marketId: log.market}).asCallback(next);
+        db("markets").update({ initialReportSize: null }).where({ marketId: log.market }).asCallback(next);
       },
       currentFeeWindow: (next: AsyncCallback) => {
         updateMarketFeeWindow(db, augur, log.universe, log.market, false, next);

--- a/src/blockchain/log-processors/market-migrated.ts
+++ b/src/blockchain/log-processors/market-migrated.ts
@@ -1,6 +1,7 @@
 import Augur from "augur.js";
 import * as Knex from "knex";
 import { FormattedEventLog, ErrorCallback, CategoriesRow, CategoryRow } from "../../types";
+import { updateMarketFeeWindow } from "./database";
 
 export function processMarketMigratedLog(db: Knex, augur: Augur, log: FormattedEventLog, callback: ErrorCallback): void {
   db.update({
@@ -9,17 +10,21 @@ export function processMarketMigratedLog(db: Knex, augur: Augur, log: FormattedE
     needsDisavowal: db.raw("needsDisavowal - 1"),
   }).into("markets").where("marketId", log.market).asCallback((err) => {
     if (err) return callback(err);
-    db.update({
-      disavowed: db.raw("disavowed + 1"),
-    }).into("crowdsourcers").where("marketId", log.market).asCallback((err) => {
-      db.select("category").from("markets").where({ marketId: log.market }).asCallback((err: Error|null, categoryRows?: Array<CategoryRow>): void => {
+    updateMarketFeeWindow(db, augur, log.newUniverse, log.market, true, (err) => {
+      if (err) return callback(err);
+      db.update({
+        disavowed: db.raw("disavowed + 1"),
+      }).into("crowdsourcers").where("marketId", log.market).asCallback((err) => {
         if (err) return callback(err);
-        if (!categoryRows || !categoryRows.length) return callback(null);
-        const category = categoryRows[0].category;
-        db.select("popularity").from("categories").where({ category, universe: log.newUniverse }).asCallback((err: Error|null, categoriesRows?: Array<CategoriesRow>): void => {
+        db.select("category").from("markets").where({ marketId: log.market }).asCallback((err: Error|null, categoryRows?: Array<CategoryRow>): void => {
           if (err) return callback(err);
-          if (categoriesRows && categoriesRows.length) return callback(null);
-          db.insert({ category, universe: log.newUniverse }).into("categories").asCallback(callback);
+          if (!categoryRows || !categoryRows.length) return callback(null);
+          const category = categoryRows[0].category;
+          db.select("popularity").from("categories").where({ category, universe: log.newUniverse }).asCallback((err: Error|null, categoriesRows?: Array<CategoriesRow>): void => {
+            if (err) return callback(err);
+            if (categoriesRows && categoriesRows.length) return callback(null);
+            db.insert({ category, universe: log.newUniverse }).into("categories").asCallback(callback);
+          });
         });
       });
     });

--- a/src/blockchain/log-processors/market-migrated.ts
+++ b/src/blockchain/log-processors/market-migrated.ts
@@ -1,29 +1,32 @@
 import Augur from "augur.js";
 import * as Knex from "knex";
-import { FormattedEventLog, ErrorCallback, CategoriesRow, CategoryRow } from "../../types";
-import { updateMarketFeeWindow } from "./database";
+import { FormattedEventLog, ErrorCallback, CategoriesRow, CategoryRow, ReportingState } from "../../types";
+import { rollbackMarketState, updateMarketFeeWindow, updateMarketState } from "./database";
 
 export function processMarketMigratedLog(db: Knex, augur: Augur, log: FormattedEventLog, callback: ErrorCallback): void {
-  db.update({
-    universe: log.newUniverse,
-    needsMigration: db.raw("needsMigration - 1"),
-    needsDisavowal: db.raw("needsDisavowal - 1"),
-  }).into("markets").where("marketId", log.market).asCallback((err) => {
+  updateMarketState(db, log.market, log.blockNumber, ReportingState.AWAITING_NEXT_WINDOW, (err) => {
     if (err) return callback(err);
     updateMarketFeeWindow(db, augur, log.newUniverse, log.market, true, (err) => {
       if (err) return callback(err);
       db.update({
-        disavowed: db.raw("disavowed + 1"),
-      }).into("crowdsourcers").where("marketId", log.market).asCallback((err) => {
+        universe: log.newUniverse,
+        needsMigration: db.raw("needsMigration - 1"),
+        needsDisavowal: db.raw("needsDisavowal - 1"),
+      }).into("markets").where("marketId", log.market).asCallback((err) => {
         if (err) return callback(err);
-        db.select("category").from("markets").where({ marketId: log.market }).asCallback((err: Error|null, categoryRows?: Array<CategoryRow>): void => {
+        db.update({
+          disavowed: db.raw("disavowed + 1"),
+        }).into("crowdsourcers").where("marketId", log.market).asCallback((err) => {
           if (err) return callback(err);
-          if (!categoryRows || !categoryRows.length) return callback(null);
-          const category = categoryRows[0].category;
-          db.select("popularity").from("categories").where({ category, universe: log.newUniverse }).asCallback((err: Error|null, categoriesRows?: Array<CategoriesRow>): void => {
+          db.select("category").from("markets").where({ marketId: log.market }).asCallback((err: Error|null, categoryRows?: Array<CategoryRow>): void => {
             if (err) return callback(err);
-            if (categoriesRows && categoriesRows.length) return callback(null);
-            db.insert({ category, universe: log.newUniverse }).into("categories").asCallback(callback);
+            if (!categoryRows || !categoryRows.length) return callback(null);
+            const category = categoryRows[0].category;
+            db.select("popularity").from("categories").where({ category, universe: log.newUniverse }).asCallback((err: Error|null, categoriesRows?: Array<CategoriesRow>): void => {
+              if (err) return callback(err);
+              if (categoriesRows && categoriesRows.length) return callback(null);
+              db.insert({ category, universe: log.newUniverse }).into("categories").asCallback(callback);
+            });
           });
         });
       });
@@ -32,14 +35,16 @@ export function processMarketMigratedLog(db: Knex, augur: Augur, log: FormattedE
 }
 
 export function processMarketMigratedLogRemoval(db: Knex, augur: Augur, log: FormattedEventLog, callback: ErrorCallback): void {
-  db.update({
-    universe: log.originalUniverse,
-    needsMigration: db.raw("needsMigration + 1"),
-    needsDisavowal: db.raw("needsDisavowal + 1"),
-  }).into("markets").where("marketId", log.market).asCallback((err) => {
-    if (err) return callback(err);
+  rollbackMarketState(db, log.market, ReportingState.AWAITING_NEXT_WINDOW, (err) => {
     db.update({
-      disavowed: db.raw("disavowed - 1"),
-    }).into("crowdsourcers").where("marketId", log.market).asCallback(callback);
+      universe: log.originalUniverse,
+      needsMigration: db.raw("needsMigration + 1"),
+      needsDisavowal: db.raw("needsDisavowal + 1"),
+    }).into("markets").where("marketId", log.market).asCallback((err) => {
+      if (err) return callback(err);
+      db.update({
+        disavowed: db.raw("disavowed - 1"),
+      }).into("crowdsourcers").where("marketId", log.market).asCallback(callback);
+    });
   });
 }

--- a/src/blockchain/log-processors/universe-forked.ts
+++ b/src/blockchain/log-processors/universe-forked.ts
@@ -1,8 +1,10 @@
 import Augur from "augur.js";
 import * as Knex from "knex";
-import { FormattedEventLog, ErrorCallback, Address, ReportingState } from "../../types";
+import { FormattedEventLog, ErrorCallback, Address, ReportingState, MarketsContractAddressRow } from "../../types";
 import { updateMarketState } from "./database";
 import { augurEmitter } from "../../events";
+import { getMarketsWithReportingState } from "../../server/getters/database";
+import { forEach } from "async";
 
 export function processUniverseForkedLog(db: Knex, augur: Augur, log: FormattedEventLog, callback: ErrorCallback): void {
   augur.api.Universe.getForkingMarket({ tx: { to: log.universe } }, (err: Error|null, forkingMarket?: Address): void => {
@@ -21,7 +23,28 @@ export function processUniverseForkedLog(db: Knex, augur: Augur, log: FormattedE
         db("markets").increment("needsDisavowal", 1).where({ universe: log.universe }).whereNot("marketId", forkingMarket)
           .asCallback((err) => {
             if (err) return callback(err);
-            db("universes").update("forked", true).where({ universe: log.universe }).asCallback(callback);
+            db("universes").update("forked", true).where({ universe: log.universe }).asCallback((err: Error|null) => {
+              if (err) return callback(err);
+              getMarketsWithReportingState(db).from("markets").select("markets.marketId")
+                .where({ universe: log.universe })
+                .whereIn("reportingState", [ReportingState.AWAITING_FINALIZATION, ReportingState.CROWDSOURCING_DISPUTE, ReportingState.AWAITING_NEXT_WINDOW])
+                .asCallback((err, marketsToRevert?: Array<MarketsContractAddressRow>) => {
+                  if (err || marketsToRevert == null) return callback(err);
+                  console.log(marketsToRevert);
+                  forEach(marketsToRevert, (marketIdRow: MarketsContractAddressRow, nextMarketId: ErrorCallback): void => {
+                    updateMarketState(db, marketIdRow.marketId, log.blockNumber, ReportingState.AWAITING_NEXT_WINDOW, (err) => {
+                      if (err) return nextMarketId(err);
+                      augurEmitter.emit("MarketState", {
+                        eventName: "MarketState",
+                        universe: log.universe,
+                        marketId: marketIdRow.marketId,
+                        reportingState: ReportingState.AWAITING_FORK_MIGRATION,
+                      });
+                      nextMarketId(null);
+                    });
+                  });
+                });
+            });
           });
       });
     });

--- a/src/blockchain/log-processors/universe-forked.ts
+++ b/src/blockchain/log-processors/universe-forked.ts
@@ -32,7 +32,7 @@ export function processUniverseForkedLog(db: Knex, augur: Augur, log: FormattedE
                   if (err || marketsToRevert == null) return callback(err);
                   console.log(marketsToRevert);
                   forEach(marketsToRevert, (marketIdRow: MarketsContractAddressRow, nextMarketId: ErrorCallback): void => {
-                    updateMarketState(db, marketIdRow.marketId, log.blockNumber, ReportingState.AWAITING_NEXT_WINDOW, (err) => {
+                    updateMarketState(db, marketIdRow.marketId, log.blockNumber, ReportingState.AWAITING_FORK_MIGRATION, (err) => {
                       if (err) return nextMarketId(err);
                       augurEmitter.emit("MarketState", {
                         eventName: "MarketState",

--- a/src/server/getters/get-dispute-info.ts
+++ b/src/server/getters/get-dispute-info.ts
@@ -2,7 +2,6 @@ import { parallel } from "async";
 import * as Knex from "knex";
 import * as _ from "lodash";
 import { Address, MarketsRowWithTime, AsyncCallback, Payout, UIStakeInfo, PayoutRow, StakeDetails, ReportingState } from "../../types";
-import { formatBigNumberAsFixed } from "../../utils/format-big-number-as-fixed";
 import { getMarketsWithReportingState, normalizePayouts, uiStakeInfoToFixed, groupByAndSum } from "./database";
 import { BigNumber } from "bignumber.js";
 import { QueryBuilder } from "knex";

--- a/test/blockchain/log-processors/market-migrated.js
+++ b/test/blockchain/log-processors/market-migrated.js
@@ -76,7 +76,7 @@ describe("blockchain/log-processors/market-migrated", () => {
             "needsMigration": 0,
             "needsDisavowal": 0,
             "feeWindow": "0x0000000000000000000000000000000000FEE000",
-            "reportingState": ReportingState.AWAITING_NEXT_WINDOW,
+            "reportingState": ReportingState.CROWDSOURCING_DISPUTE,
           },
         ]);
       },

--- a/test/blockchain/log-processors/market-migrated.js
+++ b/test/blockchain/log-processors/market-migrated.js
@@ -3,9 +3,12 @@
 const assert = require("chai").assert;
 const setupTestDb = require("../../test.database");
 const {processMarketMigratedLog, processMarketMigratedLogRemoval} = require("../../../build/blockchain/log-processors/market-migrated");
+const {getMarketsWithReportingState} = require("../../../build/server/getters/database");
+const ReportingState = require("../../../build/types").ReportingState;
 
 const getMarket = (db, params, callback) => {
-  db.select(["markets.marketId", "markets.universe", "markets.needsMigration", "markets.needsDisavowal", "feeWindow"]).from("markets").where({"markets.marketId": params.log.market}).asCallback(callback);
+  getMarketsWithReportingState(db, ["markets.marketId", "markets.universe", "markets.needsMigration", "markets.needsDisavowal", "feeWindow", "reportingState"])
+    .from("markets").where({"markets.marketId": params.log.market}).asCallback(callback);
 };
 
 describe("blockchain/log-processors/market-migrated", () => {
@@ -73,6 +76,7 @@ describe("blockchain/log-processors/market-migrated", () => {
             "needsMigration": 0,
             "needsDisavowal": 0,
             "feeWindow": "0x0000000000000000000000000000000000FEE000",
+            "reportingState": ReportingState.AWAITING_NEXT_WINDOW,
           },
         ]);
       },
@@ -85,6 +89,7 @@ describe("blockchain/log-processors/market-migrated", () => {
             "needsMigration": 1,
             "needsDisavowal": 1,
             "feeWindow": "0x0000000000000000000000000000000000FEE000",
+            "reportingState": ReportingState.CROWDSOURCING_DISPUTE,
           },
         ]);
       },


### PR DESCRIPTION
This PR addresses a few things:
1.) Markets in a forked market were progressing. Like if one was AWAITING_WINDOW, it would hit CROWDSOURCING like normal, when it isn't true. Same of some other states
2.) Markets coming out of initial reporting were always AWAITING_WINDOW, but they should be AWAITING_FORK_MIGRATION
3.) Crowdsourcers were being left completed in the forked uni and disputeRounds value not being updated.
