### PR TITLE
Fix issue with too many share balances being returned

### DIFF
--- a/src/blockchain/log-processors/market-created.ts
+++ b/src/blockchain/log-processors/market-created.ts
@@ -108,7 +108,7 @@ export function processMarketCreatedLog(db: Knex, augur: Augur, log: FormattedEv
               db.batchInsert("tokens", shareTokens.map((contractAddress: Address, outcome: number): Partial<TokensRow> => Object.assign({ contractAddress, outcome }, tokensDataToInsert)), numOutcomes).asCallback(next);
             },
             (next: AsyncCallback): void => {
-              db.batchInsert("token_supply", shareTokens.map((contractAddress: Address, outcome: number): Partial<TokensRow> => Object.assign({ token: contractAddress, supply: 0 })), numOutcomes).asCallback(next);
+              db.batchInsert("token_supply", shareTokens.map((contractAddress: Address, outcome: number): Partial<TokensRow> => Object.assign({ token: contractAddress, supply: "0" })), numOutcomes).asCallback(next);
             },
           ], (err: Error|null): void => {
             if (err) return callback(err);

--- a/src/server/getters/get-user-share-balances.ts
+++ b/src/server/getters/get-user-share-balances.ts
@@ -29,7 +29,8 @@ export function getUserShareBalances(db: Knex, augur: Augur, marketIds: Array<Ad
     .select("tokens.marketId", "tokens.outcome", "balances.balance", "markets.minPrice", "markets.maxPrice", "markets.numTicks")
     .join("markets", function() {
       this
-        .on("markets.marketId", "tokens.marketId");
+        .on("markets.marketId", "tokens.marketId")
+        .andOn("tokens.symbol", db.raw("?", "shares"));
     })
     .leftJoin("balances", function () {
       this
@@ -43,7 +44,6 @@ export function getUserShareBalances(db: Knex, augur: Augur, marketIds: Array<Ad
   query.asCallback(( err: Error|null, balances: Array<ShareTokenBalances>): void => {
     if (err != null) return callback(err);
 
-    console.log(balances);
     const balancesByMarket = _.chain(balances)
       .groupBy((row) => row.marketId)
       .mapValues((groupedBalances: Array<ShareTokenBalances>) => {


### PR DESCRIPTION
I missed the share-token filter and thus when we went through reporting rounds we returned 0 balance for all the crowdsourcers as well.