### PR TITLE
contract orderType leaks through and UI gets confused

### DIFF
--- a/src/blockchain/log-processors/order-canceled.ts
+++ b/src/blockchain/log-processors/order-canceled.ts
@@ -7,13 +7,16 @@ interface MarketIDAndOutcomeAndPrice {
   marketId: Bytes32;
   outcome: number;
   price: string|number;
+  orderType: string|number;
 }
 
 export function processOrderCanceledLog(db: Knex, augur: Augur, log: FormattedEventLog, callback: ErrorCallback): void {
+  const orderTypeLabel = log.orderType === "0" ? "buy" : "sell";
   db.from("orders").where("orderId", log.orderId).update({ orderState: OrderState.CANCELED }).asCallback((err: Error|null): void => {
     if (err) return callback(err);
     db.first("marketId", "outcome", "price").from("orders").where("orderId", log.orderId).asCallback((err: Error|null, ordersRow?: MarketIDAndOutcomeAndPrice): void => {
       if (err) return callback(err);
+      if (ordersRow) ordersRow.orderType = orderTypeLabel;
       augurEmitter.emit("OrderCanceled", Object.assign({}, log, ordersRow));
       callback(null);
     });
@@ -21,10 +24,12 @@ export function processOrderCanceledLog(db: Knex, augur: Augur, log: FormattedEv
 }
 
 export function processOrderCanceledLogRemoval(db: Knex, augur: Augur, log: FormattedEventLog, callback: ErrorCallback): void {
+  const orderTypeLabel = log.orderType === "0" ? "buy" : "sell";
   db.from("orders").where("orderId", log.orderId).update({ orderState: OrderState.OPEN }).asCallback((err: Error|null): void => {
     if (err) return callback(err);
     db.first("marketId", "outcome", "price").from("orders").where("orderId", log.orderId).asCallback((err: Error|null, ordersRow?: MarketIDAndOutcomeAndPrice): void => {
       if (err) return callback(err);
+      if (ordersRow) ordersRow.orderType = orderTypeLabel;
       augurEmitter.emit("OrderCanceled", Object.assign({}, log, ordersRow));
       callback(null);
     });


### PR DESCRIPTION
orderType is translated to buy | sell in Order Created, Order Filled, but order canceled gets 0 | 1. This will make it consistent so the UI handler can just handle "buy" and "sell"