### PR TITLE
Augur-node should save cancelled orders as new transactions instead of updating the original order transaction's status

### DIFF
--- a/src/migrations/20180504123242_orders_canceled.ts
+++ b/src/migrations/20180504123242_orders_canceled.ts
@@ -1,0 +1,16 @@
+import * as Knex from "knex";
+
+exports.up = async (knex: Knex): Promise<any> => {
+  return knex.schema.dropTableIfExists("orders_canceled").then(async (): Promise<any> => {
+    return knex.schema.createTable("orders_canceled", (table: Knex.CreateTableBuilder): void => {
+      table.string("orderId", 42).primary().notNullable();
+      table.specificType("blockNumber", "integer NOT NULL CONSTRAINT positiveOrderBlockNumber CHECK (\"blockNumber\" > 0)");
+      table.string("transactionHash", 66).notNullable();
+      table.specificType("logIndex", "integer NOT NULL CONSTRAINT \"nonnegativelogIndex\" CHECK (\"logIndex\" >= 0)");
+    });
+  });
+};
+
+exports.down = async (knex: Knex): Promise<any> => {
+  return knex.schema.dropTableIfExists("orders_canceled");
+};

--- a/src/seeds/test/orders_canceled.ts
+++ b/src/seeds/test/orders_canceled.ts
@@ -1,0 +1,15 @@
+import * as Knex from "knex";
+
+exports.seed = async (knex: Knex): Promise<any> => {
+  // Deletes ALL existing entries
+  return knex("orders_canceled").del().then(async (): Promise<any> => {
+    // Inserts seed entries
+    const seedData = [{
+      orderId: "0x4200000000000000000000000000000000000000000000000000000000000000",
+      blockNumber: 1500000,
+      transactionHash: "0x000000000000000000000000000000000000000000000000000000000000AA05",
+      logIndex: 0,
+    }];
+    return knex.batchInsert("orders_canceled", seedData, seedData.length);
+  });
+};


### PR DESCRIPTION
Story details: https://app.clubhouse.io/augur/story/11966