### PR TITLE
Add cancelation tx details to orders object, if order state is canceled

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -382,6 +382,8 @@ export interface UIOrder<BigNumberType> {
   fullPrecisionAmount: BigNumberType;
   tokensEscrowed: BigNumberType;
   sharesEscrowed: BigNumberType;
+  canceledBlockNumber?: Bytes32;
+  canceledTransactionHash?: Bytes32;
 }
 
 export interface UIOrders<BigNumberType> {

--- a/test/server/getters/get-orders.js
+++ b/test/server/getters/get-orders.js
@@ -214,6 +214,8 @@ describe("server/getters/get-orders", () => {
                 fullPrecisionAmount: "2",
                 tokensEscrowed: "1.2",
                 sharesEscrowed: "0",
+                canceledBlockNumber: 1500000,
+                canceledTransactionHash: "0x000000000000000000000000000000000000000000000000000000000000AA05",
               },
             },
           },


### PR DESCRIPTION
response object looks like this now:

```
{
        "0x0000000000000000000000000000000000000001": {
          1: {
            sell: {
              "0x4200000000000000000000000000000000000000000000000000000000000000": {
                orderId: "0x4200000000000000000000000000000000000000000000000000000000000000",
                shareToken: "0x2000000000000000000000000000000000000000",
                transactionHash: "0x0000000000000000000000000000000000000000000000000000000000000A05",
                logIndex: 0,
                owner: "0x000000000000000000000000000000000000d00d",
                creationTime: 1506473515,
                creationBlockNumber: 1400002,
                orderState: "CANCELED",
                price: "0.8",
                amount: "2",
                fullPrecisionPrice: "0.8",
                fullPrecisionAmount: "2",
                tokensEscrowed: "1.2",
                sharesEscrowed: "0",
vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
                canceledBlockNumber: 1500000,
                canceledTransactionHash: "0x000000000000000000000000000000000000000000000000000000000000AA05",
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
              },
            },
```