### PR TITLE
Remove off-chain call for order amount

### DIFF
--- a/src/blockchain/log-processors/order-filled/index.ts
+++ b/src/blockchain/log-processors/order-filled/index.ts
@@ -73,7 +73,7 @@ export function processOrderFilledLog(db: Knex, augur: Augur, log: FormattedEven
           if (err) return callback(err);
           updateVolumetrics(db, augur, category, marketId, outcome, blockNumber, orderId, orderCreator, tickSize, minPrice, maxPrice, true, (err: Error|null): void => {
             if (err) return callback(err);
-            updateOrdersAndPositions(db, augur, marketId, orderId, orderCreator, filler, tickSize, callback);
+            updateOrdersAndPositions(db, augur, marketId, orderId, amount, orderCreator, filler, tickSize, callback);
           });
         });
       });
@@ -112,7 +112,7 @@ export function processOrderFilledLogRemoval(db: Knex, augur: Augur, log: Format
         if (err) return callback(err);
         db.from("trades").where({ marketId, outcome, orderId, blockNumber }).del().asCallback((err?: Error|null): void => {
           if (err) return callback(err);
-          updateOrdersAndPositions(db, augur, marketId, orderId, orderCreator, log.filler, tickSize, (err?: Error|null) => {
+          updateOrdersAndPositions(db, augur, marketId, orderId, amount.negated(), orderCreator, log.filler, tickSize, (err?: Error|null) => {
             if (err) return callback(err);
             augurEmitter.emit("OrderFilled", Object.assign({}, log, {
               marketId,

--- a/src/blockchain/log-processors/order-filled/update-orders-and-positions.ts
+++ b/src/blockchain/log-processors/order-filled/update-orders-and-positions.ts
@@ -9,27 +9,28 @@ import { formatBigNumberAsFixed } from "../../../utils/format-big-number-as-fixe
 import { refreshPositionInMarket } from "./refresh-position-in-market";
 
 interface OrderFilledOnContractData {
-  amount: string;
+  amount: { fullPrecisionAmount: BigNumber };
 }
 
 function noop(db: Knex, augur: Augur, marketId: Address, account: Address, callback: (err: Error|null, positions?: Array<string>) => void) {
   callback(null);
 }
 
-export function updateOrdersAndPositions(db: Knex, augur: Augur, marketId: Address, orderId: Bytes32, creator: Address, filler: Address, tickSize: BigNumber, callback: ErrorCallback): void {
+export function updateOrdersAndPositions(db: Knex, augur: Augur, marketId: Address, orderId: Bytes32, amount: BigNumber, creator: Address, filler: Address, tickSize: BigNumber, callback: ErrorCallback): void {
   // If the user is taking their own order we don't refresh twice
   const fillerRefresh = creator === filler ? noop : refreshPositionInMarket;
   parallel({
-    amount: (next: AsyncCallback): void => augur.api.Orders.getAmount({ _orderId: orderId }, next),
+    amount: (next: AsyncCallback) => db("orders").first("fullPrecisionAmount").where({orderId}).asCallback(next),
     creatorPositionInMarket: (next: AsyncCallback): void => refreshPositionInMarket(db, augur, marketId, creator, next),
     fillerPositionInMarket: (next: AsyncCallback): void => fillerRefresh(db, augur, marketId, filler, next),
   }, (err: Error|null, onContractData: OrderFilledOnContractData): void => {
     if (err) return callback(err);
-    const amount: BigNumber = new BigNumber(onContractData.amount, 10);
-    const fullPrecisionAmountRemainingInOrder = augur.utils.convertOnChainAmountToDisplayAmount(amount, tickSize);
+    // const amountBeforeUpdate: BigNumber = new BigNumber(onContractData.amount.fullPrecisionAmount, 10);
+    const fullPrecisionAmountRemainingInOrder = onContractData.amount.fullPrecisionAmount.minus(amount);
     const amountRemainingInOrder = formatOrderAmount(fullPrecisionAmountRemainingInOrder);
     const updateAmountsParams = { fullPrecisionAmount: fullPrecisionAmountRemainingInOrder, amount: amountRemainingInOrder };
-    const updateParams = fullPrecisionAmountRemainingInOrder.eq(ZERO) ? Object.assign({ orderState: OrderState.FILLED }, updateAmountsParams) : updateAmountsParams;
+    const orderState = fullPrecisionAmountRemainingInOrder.eq(ZERO) ? OrderState.FILLED : OrderState.OPEN;
+    const updateParams = Object.assign({ orderState }, updateAmountsParams);
     db("orders").where({ orderId }).update(formatBigNumberAsFixed(updateParams)).asCallback(callback);
   });
 }

--- a/src/blockchain/log-processors/order-filled/update-orders-and-positions.ts
+++ b/src/blockchain/log-processors/order-filled/update-orders-and-positions.ts
@@ -25,8 +25,7 @@ export function updateOrdersAndPositions(db: Knex, augur: Augur, marketId: Addre
     fillerPositionInMarket: (next: AsyncCallback): void => fillerRefresh(db, augur, marketId, filler, next),
   }, (err: Error|null, onContractData: OrderFilledOnContractData): void => {
     if (err) return callback(err);
-    // const amountBeforeUpdate: BigNumber = new BigNumber(onContractData.amount.fullPrecisionAmount, 10);
-    const fullPrecisionAmountRemainingInOrder = onContractData.amount.fullPrecisionAmount.minus(amount);
+\    const fullPrecisionAmountRemainingInOrder = onContractData.amount.fullPrecisionAmount.minus(amount);
     const amountRemainingInOrder = formatOrderAmount(fullPrecisionAmountRemainingInOrder);
     const updateAmountsParams = { fullPrecisionAmount: fullPrecisionAmountRemainingInOrder, amount: amountRemainingInOrder };
     const orderState = fullPrecisionAmountRemainingInOrder.eq(ZERO) ? OrderState.FILLED : OrderState.OPEN;

--- a/test/unit/blockchain/log-processors/order-filled/index.js
+++ b/test/unit/blockchain/log-processors/order-filled/index.js
@@ -43,7 +43,7 @@ describe("blockchain/log-processors/order-filled", () => {
     });
   };
   test({
-    description: "OrderFilled log and removal",
+    description: "OrderFilled full log and removal",
     params: {
       log: {
         shareToken: "0x0100000000000000000000000000000000000000",
@@ -165,6 +165,354 @@ describe("blockchain/log-processors/order-filled", () => {
         ]);
         assert.deepEqual(records.categories, {
           popularity: 1,
+        });
+        assert.deepEqual(records.positions, [{
+          positionId: 21,
+          account: "FILLER_ADDRESS",
+          marketId: "0x0000000000000000000000000000000000000001",
+          outcome: 0,
+          numShares: new BigNumber("2", 10),
+          numSharesAdjustedForUserIntention: new BigNumber("2", 10),
+          realizedProfitLoss: new BigNumber("0", 10),
+          unrealizedProfitLoss: new BigNumber("0", 10),
+          averagePrice: new BigNumber("0.75", 10),
+          lastUpdated: records.positions[0].lastUpdated,
+        }, {
+          positionId: 22,
+          account: "FILLER_ADDRESS",
+          marketId: "0x0000000000000000000000000000000000000001",
+          outcome: 1,
+          numShares: new BigNumber("0", 10),
+          numSharesAdjustedForUserIntention: new BigNumber("0", 10),
+          realizedProfitLoss: new BigNumber("0", 10),
+          unrealizedProfitLoss: new BigNumber("0", 10),
+          averagePrice: new BigNumber("0", 10),
+          lastUpdated: records.positions[0].lastUpdated,
+        }, {
+          positionId: 23,
+          account: "FILLER_ADDRESS",
+          marketId: "0x0000000000000000000000000000000000000001",
+          outcome: 2,
+          numShares: new BigNumber("0", 10),
+          numSharesAdjustedForUserIntention: new BigNumber("0", 10),
+          realizedProfitLoss: new BigNumber("0", 10),
+          unrealizedProfitLoss: new BigNumber("0", 10),
+          averagePrice: new BigNumber("0", 10),
+          lastUpdated: records.positions[0].lastUpdated,
+        }, {
+          positionId: 24,
+          account: "FILLER_ADDRESS",
+          marketId: "0x0000000000000000000000000000000000000001",
+          outcome: 3,
+          numShares: new BigNumber("0", 10),
+          numSharesAdjustedForUserIntention: new BigNumber("0", 10),
+          realizedProfitLoss: new BigNumber("0", 10),
+          unrealizedProfitLoss: new BigNumber("0", 10),
+          averagePrice: new BigNumber("0", 10),
+          lastUpdated: records.positions[0].lastUpdated,
+        }, {
+          positionId: 25,
+          account: "FILLER_ADDRESS",
+          marketId: "0x0000000000000000000000000000000000000001",
+          outcome: 4,
+          numShares: new BigNumber("0", 10),
+          numSharesAdjustedForUserIntention: new BigNumber("0", 10),
+          realizedProfitLoss: new BigNumber("0", 10),
+          unrealizedProfitLoss: new BigNumber("0", 10),
+          averagePrice: new BigNumber("0", 10),
+          lastUpdated: records.positions[0].lastUpdated,
+        }, {
+          positionId: 26,
+          account: "FILLER_ADDRESS",
+          marketId: "0x0000000000000000000000000000000000000001",
+          outcome: 5,
+          numShares: new BigNumber("0", 10),
+          numSharesAdjustedForUserIntention: new BigNumber("0", 10),
+          realizedProfitLoss: new BigNumber("0", 10),
+          unrealizedProfitLoss: new BigNumber("0", 10),
+          averagePrice: new BigNumber("0", 10),
+          lastUpdated: records.positions[0].lastUpdated,
+        }, {
+          positionId: 27,
+          account: "FILLER_ADDRESS",
+          marketId: "0x0000000000000000000000000000000000000001",
+          outcome: 6,
+          numShares: new BigNumber("0", 10),
+          numSharesAdjustedForUserIntention: new BigNumber("0", 10),
+          realizedProfitLoss: new BigNumber("0", 10),
+          unrealizedProfitLoss: new BigNumber("0", 10),
+          averagePrice: new BigNumber("0", 10),
+          lastUpdated: records.positions[0].lastUpdated,
+        }, {
+          positionId: 28,
+          account: "FILLER_ADDRESS",
+          marketId: "0x0000000000000000000000000000000000000001",
+          outcome: 7,
+          numShares: new BigNumber("0", 10),
+          numSharesAdjustedForUserIntention: new BigNumber("0", 10),
+          realizedProfitLoss: new BigNumber("0", 10),
+          unrealizedProfitLoss: new BigNumber("0", 10),
+          averagePrice: new BigNumber("0", 10),
+          lastUpdated: records.positions[0].lastUpdated,
+        }]);
+      },
+      onRemoved: (err, records) => {
+        assert.ifError(err);
+        assert.deepEqual(records.orders, [{
+          orderId: "0x1000000000000000000000000000000000000000000000000000000000000000",
+          blockNumber: 1400001,
+          transactionHash: "0x0000000000000000000000000000000000000000000000000000000000000A00",
+          logIndex: 0,
+          marketId: "0x0000000000000000000000000000000000000001",
+          outcome: 0,
+          shareToken: "0x0100000000000000000000000000000000000000",
+          orderType: "buy",
+          orderCreator: "0x0000000000000000000000000000000000000b0b",
+          orderState: "OPEN",
+          fullPrecisionPrice: new BigNumber("0.7", 10),
+          fullPrecisionAmount: new BigNumber("1", 10),
+          originalFullPrecisionAmount: new BigNumber("1", 10),
+          price: new BigNumber("0.7", 10),
+          amount: new BigNumber("1", 10),
+          originalAmount: new BigNumber("1", 10),
+          tokensEscrowed: new BigNumber("0.7", 10),
+          sharesEscrowed: new BigNumber("0", 10),
+          tradeGroupId: null,
+          isRemoved: null,
+        }]);
+        assert.deepEqual(records.trades, []);
+        assert.deepEqual(records.markets, {
+          volume: new BigNumber("0", 10),
+          sharesOutstanding: new BigNumber("2", 10),
+        });
+        assert.deepEqual(records.outcomes, [
+          { price: new BigNumber("0.7", 10), volume: new BigNumber("100", 10) },
+          { price: new BigNumber("0.125", 10), volume: new BigNumber("100", 10) },
+          { price: new BigNumber("0.125", 10), volume: new BigNumber("100", 10) },
+          { price: new BigNumber("0.125", 10), volume: new BigNumber("100", 10) },
+          { price: new BigNumber("0.125", 10), volume: new BigNumber("100", 10) },
+          { price: new BigNumber("0.125", 10), volume: new BigNumber("100", 10) },
+          { price: new BigNumber("0.125", 10), volume: new BigNumber("100", 10) },
+          { price: new BigNumber("0.125", 10), volume: new BigNumber("100", 10) },
+        ]);
+        assert.deepEqual(records.categories, {
+          popularity: 0,
+        });
+        assert.deepEqual(records.positions, [{
+          positionId: 21,
+          account: "FILLER_ADDRESS",
+          marketId: "0x0000000000000000000000000000000000000001",
+          outcome: 0,
+          numShares: new BigNumber("2", 10),
+          numSharesAdjustedForUserIntention: new BigNumber("0", 10),
+          realizedProfitLoss: new BigNumber("0", 10),
+          unrealizedProfitLoss: new BigNumber("0", 10),
+          averagePrice: new BigNumber("0", 10),
+          lastUpdated: records.positions[0].lastUpdated,
+        }, {
+          positionId: 22,
+          account: "FILLER_ADDRESS",
+          marketId: "0x0000000000000000000000000000000000000001",
+          outcome: 1,
+          numShares: new BigNumber("0", 10),
+          numSharesAdjustedForUserIntention: new BigNumber("0", 10),
+          realizedProfitLoss: new BigNumber("0", 10),
+          unrealizedProfitLoss: new BigNumber("0", 10),
+          averagePrice: new BigNumber("0", 10),
+          lastUpdated: records.positions[0].lastUpdated,
+        }, {
+          positionId: 23,
+          account: "FILLER_ADDRESS",
+          marketId: "0x0000000000000000000000000000000000000001",
+          outcome: 2,
+          numShares: new BigNumber("0", 10),
+          numSharesAdjustedForUserIntention: new BigNumber("0", 10),
+          realizedProfitLoss: new BigNumber("0", 10),
+          unrealizedProfitLoss: new BigNumber("0", 10),
+          averagePrice: new BigNumber("0", 10),
+          lastUpdated: records.positions[0].lastUpdated,
+        }, {
+          positionId: 24,
+          account: "FILLER_ADDRESS",
+          marketId: "0x0000000000000000000000000000000000000001",
+          outcome: 3,
+          numShares: new BigNumber("0", 10),
+          numSharesAdjustedForUserIntention: new BigNumber("0", 10),
+          realizedProfitLoss: new BigNumber("0", 10),
+          unrealizedProfitLoss: new BigNumber("0", 10),
+          averagePrice: new BigNumber("0", 10),
+          lastUpdated: records.positions[0].lastUpdated,
+        }, {
+          positionId: 25,
+          account: "FILLER_ADDRESS",
+          marketId: "0x0000000000000000000000000000000000000001",
+          outcome: 4,
+          numShares: new BigNumber("0", 10),
+          numSharesAdjustedForUserIntention: new BigNumber("0", 10),
+          realizedProfitLoss: new BigNumber("0", 10),
+          unrealizedProfitLoss: new BigNumber("0", 10),
+          averagePrice: new BigNumber("0", 10),
+          lastUpdated: records.positions[0].lastUpdated,
+        }, {
+          positionId: 26,
+          account: "FILLER_ADDRESS",
+          marketId: "0x0000000000000000000000000000000000000001",
+          outcome: 5,
+          numShares: new BigNumber("0", 10),
+          numSharesAdjustedForUserIntention: new BigNumber("0", 10),
+          realizedProfitLoss: new BigNumber("0", 10),
+          unrealizedProfitLoss: new BigNumber("0", 10),
+          averagePrice: new BigNumber("0", 10),
+          lastUpdated: records.positions[0].lastUpdated,
+        }, {
+          positionId: 27,
+          account: "FILLER_ADDRESS",
+          marketId: "0x0000000000000000000000000000000000000001",
+          outcome: 6,
+          numShares: new BigNumber("0", 10),
+          numSharesAdjustedForUserIntention: new BigNumber("0", 10),
+          realizedProfitLoss: new BigNumber("0", 10),
+          unrealizedProfitLoss: new BigNumber("0", 10),
+          averagePrice: new BigNumber("0", 10),
+          lastUpdated: records.positions[0].lastUpdated,
+        }, {
+          positionId: 28,
+          account: "FILLER_ADDRESS",
+          marketId: "0x0000000000000000000000000000000000000001",
+          outcome: 7,
+          numShares: new BigNumber("0", 10),
+          numSharesAdjustedForUserIntention: new BigNumber("0", 10),
+          realizedProfitLoss: new BigNumber("0", 10),
+          unrealizedProfitLoss: new BigNumber("0", 10),
+          averagePrice: new BigNumber("0", 10),
+          lastUpdated: records.positions[0].lastUpdated,
+        }]);
+      },
+    },
+  });
+  test({
+    description: "OrderFilled partial log and removal",
+    params: {
+      log: {
+        shareToken: "0x0100000000000000000000000000000000000000",
+        filler: "FILLER_ADDRESS",
+        orderId: "0x1000000000000000000000000000000000000000000000000000000000000000",
+        amountFilled: "40000000000000",
+        numCreatorShares: "0",
+        numCreatorTokens: fix("0.4", "string"),
+        numFillerShares: augur.utils.convertDisplayAmountToOnChainAmount("2", new BigNumber(1), new BigNumber(10000)).toFixed(),
+        numFillerTokens: "0",
+        marketCreatorFees: "0",
+        reporterFees: "0",
+        tradeGroupId: "TRADE_GROUP_ID",
+        blockNumber: 1400101,
+        transactionHash: "0x0000000000000000000000000000000000000000000000000000000000000F00",
+        logIndex: 0,
+      },
+      augur: {
+        api: {
+          Orders: {
+            getLastOutcomePrice: (p, callback) => {
+              assert.strictEqual(p._market, "0x0000000000000000000000000000000000000001");
+              if (p._outcome === 0) {
+                callback(null, "7000");
+              } else {
+                callback(null, "1250");
+              }
+            },
+          },
+        },
+        trading: {
+          calculateProfitLoss: (p) => {
+            assert.isObject(p);
+            return {
+              position: "2",
+              realized: "0",
+              unrealized: "0",
+              meanOpenPrice: "0.75",
+              queued: "0",
+            };
+          },
+          getPositionInMarket: (p, callback) => {
+            assert.strictEqual(p.market, "0x0000000000000000000000000000000000000001");
+            assert.oneOf(p.address, ["0x0000000000000000000000000000000000000b0b", "FILLER_ADDRESS"]);
+            callback(null, ["2", "0", "0", "0", "0", "0", "0", "0"]);
+          },
+          normalizePrice: p => p.price,
+        },
+      },
+      utils: {
+        convertOnChainPriceToDisplayPrice: (onChainPrice, minDisplayPrice, tickSize) => {
+          return onChainPrice.times(tickSize).plus(minDisplayPrice);
+        },
+      },
+    },
+    aux: {
+      marketId: "0x0000000000000000000000000000000000000001",
+      category: "test category",
+    },
+    assertions: {
+      onAdded: (err, records) => {
+        assert.ifError(err);
+        assert.deepEqual(records.orders, [{
+          orderId: "0x1000000000000000000000000000000000000000000000000000000000000000",
+          blockNumber: 1400001,
+          transactionHash: "0x0000000000000000000000000000000000000000000000000000000000000A00",
+          logIndex: 0,
+          marketId: "0x0000000000000000000000000000000000000001",
+          outcome: 0,
+          shareToken: "0x0100000000000000000000000000000000000000",
+          orderType: "buy",
+          orderCreator: "0x0000000000000000000000000000000000000b0b",
+          orderState: "OPEN",
+          fullPrecisionPrice: new BigNumber("0.7", 10),
+          originalFullPrecisionAmount: new BigNumber("1", 10),
+          fullPrecisionAmount: new BigNumber("0.6", 10),
+          price: new BigNumber("0.7", 10),
+          amount: new BigNumber("0.6", 10),
+          originalAmount: new BigNumber("1", 10),
+          tokensEscrowed: new BigNumber("0.7", 10),
+          sharesEscrowed: new BigNumber("0", 10),
+          tradeGroupId: null,
+          isRemoved: null,
+        }]);
+        assert.deepEqual(records.trades, [{
+          orderId: "0x1000000000000000000000000000000000000000000000000000000000000000",
+          blockNumber: 1400101,
+          transactionHash: "0x0000000000000000000000000000000000000000000000000000000000000F00",
+          logIndex: 0,
+          marketId: "0x0000000000000000000000000000000000000001",
+          outcome: 0,
+          shareToken: "0x0100000000000000000000000000000000000000",
+          orderType: "buy",
+          creator: "0x0000000000000000000000000000000000000b0b",
+          filler: "FILLER_ADDRESS",
+          numCreatorTokens: new BigNumber("0.4", 10),
+          numCreatorShares: new BigNumber("0", 10),
+          numFillerTokens: new BigNumber("0", 10),
+          numFillerShares: new BigNumber("2", 10),
+          marketCreatorFees: new BigNumber("0", 10),
+          reporterFees: new BigNumber("0", 10),
+          price: new BigNumber("0.7", 10),
+          amount: new BigNumber("0.4", 10),
+          tradeGroupId: "TRADE_GROUP_ID",
+        }]);
+        assert.deepEqual(records.markets, {
+          volume: new BigNumber("0.4", 10),
+          sharesOutstanding: new BigNumber("2", 10),
+        });
+        assert.deepEqual(records.outcomes, [
+          { price: new BigNumber("0.7", 10), volume: new BigNumber("100.4", 10) },
+          { price: new BigNumber("0.125", 10), volume: new BigNumber("100", 10) },
+          { price: new BigNumber("0.125", 10), volume: new BigNumber("100", 10) },
+          { price: new BigNumber("0.125", 10), volume: new BigNumber("100", 10) },
+          { price: new BigNumber("0.125", 10), volume: new BigNumber("100", 10) },
+          { price: new BigNumber("0.125", 10), volume: new BigNumber("100", 10) },
+          { price: new BigNumber("0.125", 10), volume: new BigNumber("100", 10) },
+          { price: new BigNumber("0.125", 10), volume: new BigNumber("100", 10) },
+        ]);
+        assert.deepEqual(records.categories, {
+          popularity: 0.4,
         });
         assert.deepEqual(records.positions, [{
           positionId: 21,

--- a/test/unit/blockchain/log-processors/order-filled/index.js
+++ b/test/unit/blockchain/log-processors/order-filled/index.js
@@ -49,7 +49,7 @@ describe("blockchain/log-processors/order-filled", () => {
         shareToken: "0x0100000000000000000000000000000000000000",
         filler: "FILLER_ADDRESS",
         orderId: "0x1000000000000000000000000000000000000000000000000000000000000000",
-        amountFilled: "142857142857142",
+        amountFilled: "100000000000000",
         numCreatorShares: "0",
         numCreatorTokens: fix("1", "string"),
         numFillerShares: augur.utils.convertDisplayAmountToOnChainAmount("2", new BigNumber(1), new BigNumber(10000)).toFixed(),
@@ -64,10 +64,6 @@ describe("blockchain/log-processors/order-filled", () => {
       augur: {
         api: {
           Orders: {
-            getAmount: (p, callback) => {
-              assert.deepEqual(p, { _orderId: "0x1000000000000000000000000000000000000000000000000000000000000000" });
-              callback(null, augur.utils.convertDisplayAmountToOnChainAmount("2", new BigNumber(1), new BigNumber(10000)).toFixed());
-            },
             getLastOutcomePrice: (p, callback) => {
               assert.strictEqual(p._market, "0x0000000000000000000000000000000000000001");
               if (p._outcome === 0) {
@@ -120,12 +116,12 @@ describe("blockchain/log-processors/order-filled", () => {
           shareToken: "0x0100000000000000000000000000000000000000",
           orderType: "buy",
           orderCreator: "0x0000000000000000000000000000000000000b0b",
-          orderState: "OPEN",
+          orderState: "FILLED",
           fullPrecisionPrice: new BigNumber("0.7", 10),
           originalFullPrecisionAmount: new BigNumber("1", 10),
-          fullPrecisionAmount: new BigNumber("2", 10),
+          fullPrecisionAmount: new BigNumber("0", 10),
           price: new BigNumber("0.7", 10),
-          amount: new BigNumber("2", 10),
+          amount: new BigNumber("0", 10),
           originalAmount: new BigNumber("1", 10),
           tokensEscrowed: new BigNumber("0.7", 10),
           sharesEscrowed: new BigNumber("0", 10),
@@ -150,15 +146,15 @@ describe("blockchain/log-processors/order-filled", () => {
           marketCreatorFees: new BigNumber("0", 10),
           reporterFees: new BigNumber("0", 10),
           price: new BigNumber("0.7", 10),
-          amount: new BigNumber("1.42857142857142", 10),
+          amount: new BigNumber("1", 10),
           tradeGroupId: "TRADE_GROUP_ID",
         }]);
         assert.deepEqual(records.markets, {
-          volume: new BigNumber("1.42857142857142", 10),
+          volume: new BigNumber("1", 10),
           sharesOutstanding: new BigNumber("2", 10),
         });
         assert.deepEqual(records.outcomes, [
-          { price: new BigNumber("0.7", 10), volume: new BigNumber("101.42857142857142", 10) },
+          { price: new BigNumber("0.7", 10), volume: new BigNumber("101", 10) },
           { price: new BigNumber("0.125", 10), volume: new BigNumber("100", 10) },
           { price: new BigNumber("0.125", 10), volume: new BigNumber("100", 10) },
           { price: new BigNumber("0.125", 10), volume: new BigNumber("100", 10) },
@@ -168,7 +164,7 @@ describe("blockchain/log-processors/order-filled", () => {
           { price: new BigNumber("0.125", 10), volume: new BigNumber("100", 10) },
         ]);
         assert.deepEqual(records.categories, {
-          popularity: 1.42857142857142,
+          popularity: 1,
         });
         assert.deepEqual(records.positions, [{
           positionId: 21,
@@ -274,10 +270,10 @@ describe("blockchain/log-processors/order-filled", () => {
           orderCreator: "0x0000000000000000000000000000000000000b0b",
           orderState: "OPEN",
           fullPrecisionPrice: new BigNumber("0.7", 10),
-          fullPrecisionAmount: new BigNumber("2", 10),
+          fullPrecisionAmount: new BigNumber("1", 10),
           originalFullPrecisionAmount: new BigNumber("1", 10),
           price: new BigNumber("0.7", 10),
-          amount: new BigNumber("2", 10),
+          amount: new BigNumber("1", 10),
           originalAmount: new BigNumber("1", 10),
           tokensEscrowed: new BigNumber("0.7", 10),
           sharesEscrowed: new BigNumber("0", 10),


### PR DESCRIPTION
Fetching order amount from the chain is not good when freshly sync'ing a new node. That order could be gone, or could be partially taken and the update happens out of order.

the test data here was inconsistent before (an order ended up with MORE amount after an order was filled), cleaned it up.