### PR TITLE
Various fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "augur-node",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "augur-node",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "augur-node",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "description": "Augur Node",
   "author": "The Augur Developers <team@augur.net>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "augur-node",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "description": "Augur Node",
   "author": "The Augur Developers <team@augur.net>",
   "license": "MIT",

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -46,8 +46,10 @@ export class AugurNodeController {
     const handoffBlockNumber = await bulkSyncAugurNodeWithBlockchain(this.db, this.augur);
     this.controlEmitter.emit(ControlMessageType.BulkSyncFinished);
     this.logger.info("Bulk sync with blockchain complete.");
+    processQueue.kill();
     this.serverResult = runServer(this.db, this.augur, this.controlEmitter);
     startAugurListeners(this.db, this.augur, handoffBlockNumber + 1, this.shutdownCallback);
+    processQueue.resume();
   }
 
   public shutdown() {
@@ -67,6 +69,11 @@ export class AugurNodeController {
     clearOverrideTimestamp();
     // When we have real shutdown feature in augur.js and ethrpc, implement here.
     this.augur = new Augur();
+    this.logger.clear();
+  }
+
+  public isRunning() {
+    return this.running && this.db != null;
   }
 
   public async requestLatestSyncedBlock(): Promise<SyncedBlockInfo> {

--- a/src/setup/check-and-initialize-augur-db.ts
+++ b/src/setup/check-and-initialize-augur-db.ts
@@ -71,7 +71,7 @@ async function checkAndUpdateContractUploadBlock(augur: Augur, networkId: string
     oldUploadBlockNumber = Number(readFileSync(oldUploadBlockNumberFile));
   }
   const currentUploadBlockNumber = augur.contracts.uploadBlockNumbers[augur.rpc.getNetworkID()];
-  if (currentUploadBlockNumber != oldUploadBlockNumber) {
+  if (currentUploadBlockNumber !== oldUploadBlockNumber) {
     console.log(`Deleting existing DB for this configuration as the upload block number is not equal: OLD: ${oldUploadBlockNumber} NEW: ${currentUploadBlockNumber}`);
     const dbPath = getDatabasePathFromNetworkId(networkId, databaseDir);
     if (existsSync(dbPath)) {

--- a/src/setup/check-and-initialize-augur-db.ts
+++ b/src/setup/check-and-initialize-augur-db.ts
@@ -3,7 +3,7 @@ import * as Knex from "knex";
 import * as path from "path";
 import * as sqlite3 from "sqlite3";
 import { promisify, format } from "util";
-import { rename } from "fs";
+import { rename, fstat, existsSync, unlinkSync, readFileSync, writeFileSync } from "fs";
 import { NetworkConfiguration } from "augur-core";
 import { setOverrideTimestamp } from "../blockchain/process-block";
 import { postProcessDatabaseResults } from "../server/post-process-database-results";
@@ -16,6 +16,10 @@ interface NetworkIdRow {
 }
 
 function getDatabasePathFromNetworkId(networkId: string, databaseDir: string|undefined, filenameTemplate: string = "augur-%s.db") {
+  return path.join(databaseDir || path.join(__dirname, "../../"), format(filenameTemplate, networkId));
+}
+
+function getUploadBlockPathFromNetworkId(networkId: string, databaseDir: string|undefined, filenameTemplate: string = "upload-block-%s") {
   return path.join(databaseDir || path.join(__dirname, "../../"), format(filenameTemplate, networkId));
 }
 
@@ -50,6 +54,7 @@ export async function createDbAndConnect(augur: Augur, network: NetworkConfigura
       if (networkId == null) return reject(new Error("could not get networkId"));
       try {
         monitorEthereumNodeHealth(augur);
+        await checkAndUpdateContractUploadBlock(augur, networkId);
         const db = await checkAndInitializeAugurDb(augur, networkId, databaseDir);
         resolve(db);
       } catch (err) {
@@ -57,6 +62,23 @@ export async function createDbAndConnect(augur: Augur, network: NetworkConfigura
       }
     });
   });
+}
+
+async function checkAndUpdateContractUploadBlock(augur: Augur, networkId: string, databaseDir?: string): Promise<void> {
+  const oldUploadBlockNumberFile = getUploadBlockPathFromNetworkId(networkId, databaseDir);
+  let oldUploadBlockNumber = 0;
+  if (existsSync(oldUploadBlockNumberFile)) {
+    oldUploadBlockNumber = Number(readFileSync(oldUploadBlockNumberFile));
+  }
+  const currentUploadBlockNumber = augur.contracts.uploadBlockNumbers[augur.rpc.getNetworkID()];
+  if (currentUploadBlockNumber != oldUploadBlockNumber) {
+    console.log(`Deleting existing DB for this configuration as the upload block number is not equal: OLD: ${oldUploadBlockNumber} NEW: ${currentUploadBlockNumber}`);
+    const dbPath = getDatabasePathFromNetworkId(networkId, databaseDir);
+    if (existsSync(dbPath)) {
+      unlinkSync(dbPath);
+    }
+    writeFileSync(oldUploadBlockNumberFile, currentUploadBlockNumber);
+  }
 }
 
 async function isDatabaseDamaged(db: Knex): Promise<boolean> {

--- a/src/utils/logger/logger.ts
+++ b/src/utils/logger/logger.ts
@@ -32,4 +32,8 @@ export class Logger {
   public debug(...msg: Array<string>): void {
     this.loggers.forEach((logger) => logger.debug(...msg));
   }
+
+  public clear(): void {
+    this.loggers = [];
+  }
 }


### PR DESCRIPTION
- Clears the loggers out on shutdown
- Clears and starts the process queue back up again when starting up
- Saves last known upload block for the netID to a file and on change will delete the corresponding DB and update the upload block number. This will remove the need to delete dbs manually on testnets