### PR TITLE
Suppress EventEmitter warnings, since we don't know how many users will be using subscriptions

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -1,3 +1,6 @@
 import { EventEmitter} from "events";
 
 export const augurEmitter: EventEmitter = new EventEmitter();
+
+// Purposefully setting this to 0 because we need one per websocket client
+augurEmitter.setMaxListeners(0);


### PR DESCRIPTION
If a user has multiple local connections, or refreshes before the websocket stuff can timeout, this will emit warnings