### PR TITLE
add callbacks so augur-app knows when to start back up after reset

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -57,7 +57,7 @@ export class AugurNodeController {
     }
   }
 
-  public shutdown(errorCallback: ErrorCallback | undefined) {
+  public shutdown() {
     try {
       if (!this.running) return;
       this.running = false;
@@ -76,9 +76,8 @@ export class AugurNodeController {
       // When we have real shutdown feature in augur.js and ethrpc, implement here.
       this.augur = new Augur();
       this.logger.clear();
-      if (errorCallback) errorCallback(null);
     } catch (err) {
-      if (errorCallback) errorCallback(err);
+      if (this.errorCallback) this.errorCallback(err);
     }
   }
 
@@ -108,7 +107,7 @@ export class AugurNodeController {
           networkId = fetchedNetworkId;
         }
       }
-      if (this.isRunning()) this.shutdown(undefined);
+      if (this.isRunning()) this.shutdown();
       await renameDatabaseFile(networkId, this.databaseDir).catch(errorCallback);
     } catch (err) {
       if (errorCallback) errorCallback(err);

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -57,9 +57,9 @@ export class AugurNodeController {
     }
   }
 
-  public shutdown() {
+  public async shutdown() {
     try {
-      this._shutdown();
+      await this._shutdown();
     } catch (err) {
       if (this.errorCallback) this.errorCallback(err);
     }
@@ -88,7 +88,7 @@ export class AugurNodeController {
       if (this.augur != null && this.augur.rpc.getNetworkID()) {
         networkId = this.augur.rpc.getNetworkID();
       }
-      if (this.isRunning()) this._shutdown();
+      if (this.isRunning()) await this._shutdown();
       await renameDatabaseFile(networkId, this.databaseDir);
     } catch (err) {
       if (errorCallback) errorCallback(err);
@@ -111,7 +111,7 @@ export class AugurNodeController {
     process.exit(1);
   }
 
-  private _shutdown() {
+  private async _shutdown() {
     if (!this.running) return;
     this.running = false;
     this.logger.info("Stopping Augur Node Server");
@@ -122,7 +122,7 @@ export class AugurNodeController {
       this.serverResult = undefined;
     }
     if (this.db !== undefined) {
-      this.db.destroy();
+      await this.db.destroy();
       this.db = undefined;
     }
     clearOverrideTimestamp();

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -108,13 +108,8 @@ export class AugurNodeController {
           networkId = fetchedNetworkId;
         }
       }
-      if (this.isRunning()) {
-        this.shutdown(async (err: Error|null) => {
-          await renameDatabaseFile(networkId, this.databaseDir).catch(errorCallback);
-        });
-      } else {
-        await renameDatabaseFile(networkId, this.databaseDir).catch(errorCallback);
-      }
+      if (this.isRunning()) this.shutdown(undefined);
+      await renameDatabaseFile(networkId, this.databaseDir).catch(errorCallback);
     } catch (err) {
       if (errorCallback) errorCallback(err);
     }

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -111,7 +111,6 @@ export class AugurNodeController {
       if (this.isRunning()) {
         this.shutdown(async (err: Error|null) => {
           await renameDatabaseFile(networkId, this.databaseDir).catch(errorCallback);
-          return;
         });
       } else {
         await renameDatabaseFile(networkId, this.databaseDir).catch(errorCallback);

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -89,7 +89,7 @@ export class AugurNodeController {
         networkId = this.augur.rpc.getNetworkID();
       }
       if (this.isRunning()) this._shutdown();
-      await renameDatabaseFile(networkId, this.databaseDir).catch(errorCallback);
+      await renameDatabaseFile(networkId, this.databaseDir);
     } catch (err) {
       if (errorCallback) errorCallback(err);
     }

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -85,11 +85,8 @@ export class AugurNodeController {
   public async resetDatabase(id: string, errorCallback: ErrorCallback | undefined) {
     let networkId = id || "1";
     try {
-      if (this.augur != null) {
-        const fetchedNetworkId = this.augur.rpc.getNetworkID();
-        if (fetchedNetworkId) {
-          networkId = fetchedNetworkId;
-        }
+      if (this.augur != null && this.augur.rpc.getNetworkID()) {
+        networkId = this.augur.rpc.getNetworkID();
       }
       if (this.isRunning()) this._shutdown();
       await renameDatabaseFile(networkId, this.databaseDir).catch(errorCallback);

--- a/src/runServer.ts
+++ b/src/runServer.ts
@@ -13,7 +13,7 @@ const augurNodeController = new AugurNodeController(augur, networkConfig);
 augur.rpc.setDebugOptions({ broadcast: false });
 augur.events.nodes.ethereum.on("disconnect", (event) => {
   logger.warn("Disconnected from Ethereum node", event);
-  augurNodeController.shutdown();
+  augurNodeController.shutdown(undefined);
   throw new Error("Disconnected from Ethereum node");
 });
 

--- a/src/runServer.ts
+++ b/src/runServer.ts
@@ -13,7 +13,7 @@ const augurNodeController = new AugurNodeController(augur, networkConfig);
 augur.rpc.setDebugOptions({ broadcast: false });
 augur.events.nodes.ethereum.on("disconnect", (event) => {
   logger.warn("Disconnected from Ethereum node", event);
-  augurNodeController.shutdown(undefined);
+  augurNodeController.shutdown();
   throw new Error("Disconnected from Ethereum node");
 });
 


### PR DESCRIPTION
https://app.clubhouse.io/augur/story/13690/augur-app-design-adjustments


augur-app doesn't know when to restart after `reset database`, adding callbacks.

also added passing in networkId so the reset database method knows what database to rename. If augur controller has never started then `this.augur.rpc.getNetworkID();` always returns null and mainnet database gets reset.