### PR TITLE
Inform user of the likely config issue (instead of just eth_call returned 0x)

### DIFF
--- a/src/blockchain/monitor-ethereum-node-health.ts
+++ b/src/blockchain/monitor-ethereum-node-health.ts
@@ -15,7 +15,7 @@ export function monitorEthereumNodeHealth(errorCallback: ErrorCallback | undefin
     augur.api.Universe.getController({ tx: { to: universe } }, (err: Error, universeController: string) => {
       if (err) {
         clearInterval(monitorEthereumNodeHealthId);
-        if (errorCallback) errorCallback(err);
+        if (errorCallback) errorCallback(new Error(`Controller Match Lookup Error. Check if universe "${universe}" exists. ${err.message}`));
       }
       if (universeController !== controller) {
         clearInterval(monitorEthereumNodeHealthId);


### PR DESCRIPTION
Now that we return an error on a failing eth_call, the message here for universe not existing is not friendly. 
