### PR TITLE
Serialize DB access on sqlite.

### DIFF
--- a/src/blockchain/log-processors/initial-report-submitted.ts
+++ b/src/blockchain/log-processors/initial-report-submitted.ts
@@ -1,6 +1,6 @@
 import Augur from "augur.js";
 import * as Knex from "knex";
-import { parallel } from "async";
+import { series } from "async";
 import { FormattedEventLog, ErrorCallback, AsyncCallback, Address, ReportingState } from "../../types";
 import { updateMarketState, rollbackMarketState, insertPayout, updateMarketFeeWindow, updateDisputeRound, refreshMarketMailboxEthBalance } from "./database";
 import { augurEmitter } from "../../events";
@@ -24,7 +24,7 @@ export function processInitialReportSubmittedLog(db: Knex, augur: Augur, log: Fo
           payoutId,
           redeemed: false,
         };
-        parallel({
+        series({
           initialReport: (next: AsyncCallback) => {
             augur.api.Market.getInitialReporter({ tx: { to: log.market } }, (err: Error|null, initialReporter?: Address): void => {
               if (err) return next(err);
@@ -52,7 +52,7 @@ export function processInitialReportSubmittedLog(db: Knex, augur: Augur, log: Fo
 }
 
 export function processInitialReportSubmittedLogRemoval(db: Knex, augur: Augur, log: FormattedEventLog, callback: ErrorCallback): void {
-  parallel(
+  series(
     {
       marketState: (next: AsyncCallback) => {
         rollbackMarketState(db, log.market, augur.constants.REPORTING_STATE.AWAITING_NEXT_WINDOW, (err: Error|null) => {

--- a/src/blockchain/log-processors/initial-report-submitted.ts
+++ b/src/blockchain/log-processors/initial-report-submitted.ts
@@ -1,6 +1,6 @@
 import Augur from "augur.js";
 import * as Knex from "knex";
-import { series } from "async";
+import { parallel } from "async";
 import { FormattedEventLog, ErrorCallback, AsyncCallback, Address, ReportingState } from "../../types";
 import { updateMarketState, rollbackMarketState, insertPayout, updateMarketFeeWindow, updateDisputeRound, refreshMarketMailboxEthBalance } from "./database";
 import { augurEmitter } from "../../events";
@@ -24,7 +24,7 @@ export function processInitialReportSubmittedLog(db: Knex, augur: Augur, log: Fo
           payoutId,
           redeemed: false,
         };
-        series({
+        parallel({
           initialReport: (next: AsyncCallback) => {
             augur.api.Market.getInitialReporter({ tx: { to: log.market } }, (err: Error|null, initialReporter?: Address): void => {
               if (err) return next(err);
@@ -52,7 +52,7 @@ export function processInitialReportSubmittedLog(db: Knex, augur: Augur, log: Fo
 }
 
 export function processInitialReportSubmittedLogRemoval(db: Knex, augur: Augur, log: FormattedEventLog, callback: ErrorCallback): void {
-  series(
+  parallel(
     {
       marketState: (next: AsyncCallback) => {
         rollbackMarketState(db, log.market, augur.constants.REPORTING_STATE.AWAITING_NEXT_WINDOW, (err: Error|null) => {

--- a/src/blockchain/log-processors/market-created.ts
+++ b/src/blockchain/log-processors/market-created.ts
@@ -13,6 +13,7 @@ import { getCurrentTime } from "../process-block";
 
 export function processMarketCreatedLog(db: Knex, augur: Augur, log: FormattedEventLog, callback: ErrorCallback): void {
   const marketPayload: {} = { tx: { to: log.market } };
+  const universePayload: {} = { tx: { to: log.universe, send: false } };
   parallel({
     feeWindow: (next: AsyncCallback): void => augur.api.Market.getFeeWindow(marketPayload, next),
     endTime: (next: AsyncCallback): void => augur.api.Market.getEndTime(marketPayload, next),
@@ -20,16 +21,13 @@ export function processMarketCreatedLog(db: Knex, augur: Augur, log: FormattedEv
     marketCreatorMailbox: (next: AsyncCallback): void => augur.api.Market.getMarketCreatorMailbox(marketPayload, next),
     numTicks: (next: AsyncCallback): void => augur.api.Market.getNumTicks(marketPayload, next),
     marketCreatorSettlementFeeDivisor: (next: AsyncCallback): void => augur.api.Market.getMarketCreatorSettlementFeeDivisor(marketPayload, next),
-  }, (err: Error|null, onMarketContractData?: any): void => {
+    reportingFeeDivisor: (next: AsyncCallback): void => augur.api.Universe.getOrCacheReportingFeeDivisor(universePayload, next),
+  }, (err: Error|null, onContractData?: any): void => {
     if (err) return callback(err);
-    if (!onMarketContractData) return callback(new Error(`Could not fetch market details for market: ${log.market}`));
-    const universePayload: {} = { tx: { to: log.universe, send: false } };
-    series({
-      reportingFeeDivisor: (next: AsyncCallback): void => augur.api.Universe.getOrCacheReportingFeeDivisor(universePayload, next),
-      designatedReportStake: (next: AsyncCallback) => db("balances_detail").first("balance").where({owner: log.market, symbol: "REP"}).asCallback(next),
-    }, (err?: any, onUniverseContractData?: any): void => {
+    if (!onContractData) return callback(new Error(`Could not fetch market details for market: ${log.market}`));
+    db("balances_detail").first("balance").where({owner: log.market, symbol: "REP"}).asCallback((err?: any, designatedReportStakeRow?: {balance: BigNumber}): void => {
       if (err) return callback(err);
-      if (onUniverseContractData.designatedReportStake == null) return callback(new Error(`No REP balance on market: ${log.market} (${log.transactionHash}`));
+      if (designatedReportStakeRow == null) return callback(new Error(`No REP balance on market: ${log.market} (${log.transactionHash}`));
       const marketStateDataToInsert: { [index: string]: string|number|boolean } = {
         marketId: log.market,
         reportingState: augur.constants.REPORTING_STATE.PRE_REPORTING,
@@ -60,17 +58,17 @@ export function processMarketCreatedLog(db: Knex, augur: Augur, log: FormattedEv
           universe:                   log.universe,
           numOutcomes,
           marketStateId,
-          feeWindow:                  onMarketContractData.feeWindow,
-          endTime:                    parseInt(onMarketContractData.endTime!, 10),
-          designatedReporter:         onMarketContractData.designatedReporter,
-          designatedReportStake:      convertFixedPointToDecimal(onUniverseContractData!.designatedReportStake.balance, WEI_PER_ETHER),
-          numTicks:                   onMarketContractData.numTicks,
-          marketCreatorFeeRate:       convertDivisorToRate(onMarketContractData.marketCreatorSettlementFeeDivisor!, 10),
-          marketCreatorMailbox:       onMarketContractData.marketCreatorMailbox,
+          feeWindow:                  onContractData.feeWindow,
+          endTime:                    parseInt(onContractData.endTime!, 10),
+          designatedReporter:         onContractData.designatedReporter,
+          designatedReportStake:      convertFixedPointToDecimal(designatedReportStakeRow.balance, WEI_PER_ETHER),
+          numTicks:                   onContractData.numTicks,
+          marketCreatorFeeRate:       convertDivisorToRate(onContractData.marketCreatorSettlementFeeDivisor!, 10),
+          marketCreatorMailbox:       onContractData.marketCreatorMailbox,
           marketCreatorMailboxOwner:  log.marketCreator,
           initialReportSize:          null,
-          reportingFeeRate:           convertDivisorToRate(onUniverseContractData!.reportingFeeDivisor!, 10),
-          marketCreatorFeesBalance: "0",
+          reportingFeeRate:           convertDivisorToRate(onContractData.reportingFeeDivisor!, 10),
+          marketCreatorFeesBalance:   "0",
           volume:                     "0",
           sharesOutstanding:          "0",
           forking:                    0,

--- a/src/blockchain/log-processors/order-filled/update-volumetrics.ts
+++ b/src/blockchain/log-processors/order-filled/update-volumetrics.ts
@@ -1,7 +1,7 @@
 import { Augur } from "augur.js";
 import BigNumber from "bignumber.js";
 import * as Knex from "knex";
-import { parallel } from "async";
+import { series } from "async";
 import { Address, Bytes32, TradesRow, ErrorCallback, GenericCallback } from "../../../types";
 
 function incrementMarketVolume(db: Knex, marketId: Address, amount: BigNumber, callback: GenericCallback<BigNumber>) {
@@ -55,7 +55,7 @@ export function updateVolumetrics(db: Knex, augur: Augur, category: string, mark
             let amount = tradesRow.amount!;
             if (!isIncrease) amount = amount.negated();
 
-            parallel({
+            series({
               market: (next) => incrementMarketVolume(db, marketId, amount, next),
               outcome: (next) => incrementOutcomeVolume(db, marketId, outcome, amount, next),
               category: (next) => incrementCategoryPopularity(db, category, amount, next),

--- a/src/blockchain/log-processors/reporting-participant-disavowed.ts
+++ b/src/blockchain/log-processors/reporting-participant-disavowed.ts
@@ -1,7 +1,7 @@
 import Augur from "augur.js";
 import * as Knex from "knex";
 import { FormattedEventLog, ErrorCallback, AsyncCallback } from "../../types";
-import { parallel } from "async";
+import { series } from "async";
 import { augurEmitter } from "../../events";
 
 interface ParticipantUpdateResult {
@@ -10,7 +10,7 @@ interface ParticipantUpdateResult {
 }
 
 export function processReportingParticipantDisavowedLog(db: Knex, augur: Augur, log: FormattedEventLog, callback: ErrorCallback): void {
-  parallel({
+  series({
     initialReporter: (next: AsyncCallback) => db("initial_reports").update("disavowed", 1).where({initialReporter: log.reportingParticipant }).asCallback(next),
     crowdsourcer: (next: AsyncCallback) => db("crowdsourcers").update("disavowed", 1).where({crowdsourcerId: log.reportingParticipant}).asCallback(next),
   }, (err, participantUpdateResult: ParticipantUpdateResult) => {
@@ -28,7 +28,7 @@ export function processReportingParticipantDisavowedLog(db: Knex, augur: Augur, 
 }
 
 export function processReportingParticipantDisavowedLogRemoval(db: Knex, augur: Augur, log: FormattedEventLog, callback: ErrorCallback): void {
-  parallel({
+  series({
     initialReporter: (next: AsyncCallback) => db("initial_reports").update("disavowed", 0).where({initialReporter: log.reportingParticipant }).asCallback(next),
     crowdsourcer: (next: AsyncCallback) => db("crowdsourcers").update("disavowed", 0).where({crowdsourcerId: log.reportingParticipant}).asCallback(next),
   }, (err, participantUpdateResult: ParticipantUpdateResult) => {

--- a/src/blockchain/process-block.ts
+++ b/src/blockchain/process-block.ts
@@ -1,5 +1,5 @@
 import Augur from "augur.js";
-import { parallel } from "async";
+import { series } from "async";
 import * as Knex from "knex";
 import { each } from "async";
 import { augurEmitter } from "../events";
@@ -143,7 +143,7 @@ function _processBlockRemoval(db: Knex, block: BlockDetail, callback: ErrorCallb
 }
 
 function advanceTime(db: Knex, augur: Augur, blockNumber: number, timestamp: number, callback: AsyncCallback) {
-  parallel([
+  series([
     (next: AsyncCallback) => advanceMarketReachingEndTime(db, augur, blockNumber, timestamp, next),
     (next: AsyncCallback) => advanceMarketMissingDesignatedReport(db, augur, blockNumber, timestamp, next),
     (next: AsyncCallback) => advanceFeeWindowActive(db, augur, blockNumber, timestamp, next),

--- a/src/server/getters/get-dispute-info.ts
+++ b/src/server/getters/get-dispute-info.ts
@@ -1,4 +1,4 @@
-import { parallel } from "async";
+import { series } from "async";
 import * as Knex from "knex";
 import * as _ from "lodash";
 import { Address, MarketsRowWithTime, AsyncCallback, Payout, UIStakeInfo, PayoutRow, StakeDetails, ReportingState } from "../../types";
@@ -118,7 +118,7 @@ function calculateBondSize(totalCompletedStakeOnAllPayouts: BigNumber, completed
 export function getDisputeInfo(db: Knex, marketIds: Array<Address>, account: Address|null, callback: (err: Error|null, result?: Array<UIStakeInfo<string>|null>) => void): void {
   if (marketIds == null) return callback(new Error("must include marketIds parameter"));
 
-  parallel({
+  series({
     markets: (next: AsyncCallback) => getMarketsWithReportingState(db).whereIn("markets.marketId", marketIds).asCallback(next),
     payouts: (next: AsyncCallback) => db("payouts").whereIn("marketId", marketIds).asCallback(next),
     stakesCompleted: (next: AsyncCallback) => getCompletedStakes(db, marketIds, next),

--- a/src/server/getters/get-fee-window-current.ts
+++ b/src/server/getters/get-fee-window-current.ts
@@ -1,6 +1,6 @@
 import * as Knex from "knex";
 import { Address, AsyncCallback, FeeWindowRow, FeeWindowState, UIFeeWindowCurrent } from "../../types";
-import { parallel } from "async";
+import { series } from "async";
 import { BigNumber } from "bignumber.js";
 import { sumBy } from "./database";
 import { ZERO } from "../../constants";
@@ -62,7 +62,7 @@ export function getFeeWindowCurrent(db: Knex, augur: Augur, universe: Address, r
         })
         .where("fee_windows.feeWindow", feeWindowRow.feeWindow);
 
-      parallel({
+      series({
         participantContributions: (next: AsyncCallback) => {
           participantQuery.asCallback((err: Error|null, results?: Array<{ amountStaked: BigNumber }>) => {
             if (err || results == null || results.length === 0) return next(err, ZERO);

--- a/src/server/getters/get-markets-info.ts
+++ b/src/server/getters/get-markets-info.ts
@@ -1,4 +1,4 @@
-import { parallel } from "async";
+import { series } from "async";
 import * as Knex from "knex";
 import * as _ from "lodash";
 import { BigNumber } from "bignumber.js";
@@ -18,7 +18,7 @@ export function getMarketsInfo(db: Knex, marketIds: Array<Address>, callback: (e
   marketsQuery.whereIn("markets.marketId", cleanedMarketIds);
   marketsQuery.leftJoin("blocks as finalizationBlockNumber", "finalizationBlockNumber.blockNumber", "markets.finalizationBlockNumber").select("finalizationBlockNumber.timestamp as finalizationTime");
 
-  parallel({
+  series({
     marketsRows: (next: AsyncCallback) => marketsQuery.asCallback(next),
     outcomesRows: (next: AsyncCallback) => db("outcomes").whereIn("marketId", cleanedMarketIds).asCallback(next),
     winningPayoutRows: (next: AsyncCallback) => db("payouts").whereIn("marketId", cleanedMarketIds).where("winning", 1).asCallback(next),

--- a/src/server/getters/get-reporting-fees.ts
+++ b/src/server/getters/get-reporting-fees.ts
@@ -1,4 +1,4 @@
-import { parallel } from "async";
+import { series } from "async";
 import * as Knex from "knex";
 import * as _ from "lodash";
 import { BigNumber } from "bignumber.js";
@@ -243,7 +243,7 @@ function getMarketsReportingParticipants(db: Knex, reporter: Address, universe: 
     .where("markets.universe", universe)
     .join("market_state", "markets.marketId", "market_state.marketId");
 
-  parallel({
+  series({
     initialReporters: (next: AsyncCallback) => initialReportersQuery.asCallback(next),
     crowdsourcers: (next: AsyncCallback) => crowdsourcersQuery.asCallback(next),
     forkedMarket: (next: AsyncCallback) => forkedMarketQuery.asCallback(next),
@@ -289,7 +289,7 @@ function getStakedRepResults(db: Knex, reporter: Address, universe: Address, cal
     .where("initial_reports.reporter", reporter)
     .whereNot("initial_reports.redeemed", 1);
 
-  parallel({
+  series({
     crowdsourcers: (next: AsyncCallback) => crowdsourcerQuery.asCallback(next),
     initialReporters: (next: AsyncCallback) => initialReportersQuery.asCallback(next),
   }, (err: Error|null, result: StakedRepResults) => {

--- a/src/server/getters/get-reporting-history.ts
+++ b/src/server/getters/get-reporting-history.ts
@@ -2,7 +2,7 @@ import * as Knex from "knex";
 import { Address, AsyncCallback, JoinedReportsMarketsRow, UIReport } from "../../types";
 import { formatBigNumberAsFixed } from "../../utils/format-big-number-as-fixed";
 import { queryModifier } from "./database";
-import { parallel } from "async";
+import { series } from "async";
 
 export interface UIReports<BigNumberType> {
   [universe: string]: {
@@ -68,7 +68,7 @@ export function getReportingHistory(db: Knex, reporter: Address, universe: Addre
   crowdsourcersQuery.join("markets", "markets.marketId", "crowdsourcers.marketId");
   crowdsourcersQuery.join("payouts", "crowdsourcers.payoutId", "payouts.payoutId");
   if (marketId != null) crowdsourcersQuery.where("crowdsourcers.marketId", marketId);
-  parallel({
+  series({
     initialReport: (next: AsyncCallback) => queryModifier(db, initialReportQuery, "creationBlockNumber", "asc", sortBy, isSortDescending, limit, offset, next),
     crowdsourcers: (next: AsyncCallback) => queryModifier(db, crowdsourcersQuery, "creationBlockNumber", "asc", sortBy, isSortDescending, limit, offset, next),
   }, (err: Error|null, participantResults: ParticipantResults<BigNumber>): void => {

--- a/src/utils/convert-fixed-point-to-decimal.ts
+++ b/src/utils/convert-fixed-point-to-decimal.ts
@@ -4,7 +4,7 @@ export function fixedPointToDecimal(fixedPointValue: BigNumber, conversionFactor
   return fixedPointValue.dividedBy(conversionFactor);
 }
 
-export function convertFixedPointToDecimal(fixedPointValue: string|number, conversionFactor: string|number): string {
+export function convertFixedPointToDecimal(fixedPointValue: string|number|BigNumber, conversionFactor: string|number): string {
   return fixedPointToDecimal(new BigNumber(fixedPointValue, 10), new BigNumber(conversionFactor, 10)).toFixed();
 }
 

--- a/test/unit/blockchain/log-processors/fee-window-created.js
+++ b/test/unit/blockchain/log-processors/fee-window-created.js
@@ -2,10 +2,10 @@
 
 const assert = require("chai").assert;
 const setupTestDb = require("../../test.database");
-const {parallel} = require("async");
+const {series} = require("async");
 const {processFeeWindowCreatedLog, processFeeWindowCreatedLogRemoval} = require("../../../../build/blockchain/log-processors/fee-window-created");
 
-const getFeeWindow = (db, params, callback) => parallel({
+const getFeeWindow = (db, params, callback) => series({
   fee_windows: next => db("fee_windows").first(["feeWindow", "feeWindowId", "endTime"]).where({feeWindow: params.log.feeWindow}).asCallback(next),
   tokens: next => db("tokens").select(["contractAddress", "symbol", "feeWindow"])
     .where("contractAddress", params.log.feeWindow)

--- a/test/unit/blockchain/log-processors/market-created.js
+++ b/test/unit/blockchain/log-processors/market-created.js
@@ -2,7 +2,7 @@
 
 const Augur = require("augur.js");
 const assert = require("chai").assert;
-const {parallel} = require("async");
+const {series} = require("async");
 const {BigNumber} = require("bignumber.js");
 const setupTestDb = require("../../test.database");
 const {processMarketCreatedLog, processMarketCreatedLogRemoval} = require("../../../../build/blockchain/log-processors/market-created");
@@ -10,7 +10,7 @@ const {getMarketsWithReportingState} = require("../../../../build/server/getters
 
 describe("blockchain/log-processors/market-created", () => {
   const test = (t) => {
-    const getState = (db, params, callback) => parallel({
+    const getState = (db, params, callback) => series({
       markets: next => getMarketsWithReportingState(db).where({"markets.marketId": params.log.market}).asCallback(next),
       categories: next => db("categories").where({category: params.log.topic}).asCallback(next),
       outcomes: next => db("outcomes").where({marketId: params.log.market}).asCallback(next),

--- a/test/unit/blockchain/log-processors/market-finalized.js
+++ b/test/unit/blockchain/log-processors/market-finalized.js
@@ -6,10 +6,10 @@ const setupTestDb = require("../../test.database");
 const {BigNumber} = require("bignumber.js");
 const {processMarketFinalizedLog, processMarketFinalizedLogRemoval} = require("../../../../build/blockchain/log-processors/market-finalized");
 const {getMarketsWithReportingState} = require("../../../../build/server/getters/database");
-const {parallel} = require("async");
+const {series} = require("async");
 
 const getMarketState = (db, params, callback) => {
-  parallel({
+  series({
     market: (next) => getMarketsWithReportingState(db, ["markets.marketId", "market_state.reportingState", "marketCreatorFeesBalance"]).first().where({"markets.marketId": params.log.market}).asCallback(next),
     winningPayout: (next) => db("payouts").where({marketId: params.log.market, "winning": 1}).first().asCallback(next),
   }, callback);

--- a/test/unit/blockchain/log-processors/order-canceled.js
+++ b/test/unit/blockchain/log-processors/order-canceled.js
@@ -3,14 +3,14 @@
 const assert = require("chai").assert;
 const setupTestDb = require("../../test.database");
 const {BigNumber} = require("bignumber.js");
-const {parallel} = require("async");
+const {series} = require("async");
 const {processOrderCanceledLog, processOrderCanceledLogRemoval} = require("../../../../build/blockchain/log-processors/order-canceled");
 
 describe("blockchain/log-processors/order-canceled", () => {
   const test = (t) => {
     const getState = (db, params, callback) => {
 
-      parallel({
+      series({
         order: (next) => db("orders").where("orderId", params.log.orderId).first().asCallback(next),
         orderCanceled: (next) => db("orders_canceled").where("orderId", params.log.orderId).first().asCallback(next),
       }, callback);

--- a/test/unit/blockchain/log-processors/order-filled/index.js
+++ b/test/unit/blockchain/log-processors/order-filled/index.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const assert = require("chai").assert;
-const { parallel } = require("async");
+const { series } = require("async");
 const { BigNumber } = require("bignumber.js");
 const { fix } = require("speedomatic");
 const setupTestDb = require("../../../test.database");
@@ -11,7 +11,7 @@ const augur = new Augur();
 
 describe("blockchain/log-processors/order-filled", () => {
   const test = (t) => {
-    const getState = (db, params, aux, callback) => parallel({
+    const getState = (db, params, aux, callback) => series({
       orders: next => db("orders").where("orderId", params.log.orderId).asCallback(next),
       trades: next => db("trades").where("orderId", params.log.orderId).asCallback(next),
       markets: next => db.first("volume", "sharesOutstanding").from("markets").where("marketId", aux.marketId).asCallback(next),

--- a/test/unit/blockchain/log-processors/reporting-participant-disavowed.js
+++ b/test/unit/blockchain/log-processors/reporting-participant-disavowed.js
@@ -3,10 +3,10 @@
 const assert = require("chai").assert;
 const setupTestDb = require("../../test.database");
 const {processReportingParticipantDisavowedLog, processReportingParticipantDisavowedLogRemoval} = require("../../../../build/blockchain/log-processors/reporting-participant-disavowed");
-const {parallel} = require("async");
+const {series} = require("async");
 
 const getParticipantState = (db, params, callback) => {
-  parallel({
+  series({
     initialReporter: (next) => db("initial_reports").first(["initialReporter", "disavowed"]).where("initialReporter", params.log.reportingParticipant).asCallback(next),
     crowdsourcer: (next) => db("crowdsourcers").first(["crowdsourcerId", "disavowed"]).where("crowdsourcerId", params.log.reportingParticipant).asCallback(next),
   }, callback);

--- a/test/unit/blockchain/log-processors/universe-forked.js
+++ b/test/unit/blockchain/log-processors/universe-forked.js
@@ -2,12 +2,12 @@
 
 const assert = require("chai").assert;
 const setupTestDb = require("../../test.database");
-const {parallel} = require("async");
+const {series} = require("async");
 const {processUniverseForkedLog, processUniverseForkedLogRemoval} = require("../../../../build/blockchain/log-processors/universe-forked");
 
 const otherMarket = "0x0000000000000000000000000000000000000222";
 
-const getForkRows = (db, params, callback) => parallel({
+const getForkRows = (db, params, callback) => series({
   forkingMarket: next => db("markets").where({universe: params.log.universe, forking: 1}).asCallback(next),
   otherMarket: next => db("markets").where({marketId: otherMarket}).asCallback(next),
   universe: next => db("universes").where({universe: params.log.universe}).asCallback(next),


### PR DESCRIPTION
Serialize things that are going to be done sequentially anyway, due to sqlite. I'm unsure why we were seeing these race conditions but doing them in parallel is not faster, and has the possibility to be slower.

I kept parallel for things that make off-chain calls, since those benefit from parallelism.