### PR TITLE
Fix UnhandledPromiseRejectionWarning in db creation

### DIFF
--- a/src/blockchain/log-processors/token/increase-token-supply.ts
+++ b/src/blockchain/log-processors/token/increase-token-supply.ts
@@ -1,6 +1,5 @@
 import { Augur } from "augur.js";
 import * as Knex from "knex";
-import * as _ from "lodash";
 import { BigNumber } from "bignumber.js";
 import { Address, ErrorCallback } from "../../../types";
 
@@ -12,7 +11,6 @@ export function increaseTokenSupply(db: Knex, augur: Augur, token: Address, amou
   db.first("supply").from("token_supply").where({ token }).asCallback((err: Error|null, oldSupply?: SupplyResult): void => {
     if (err) return callback(err);
     if (oldSupply == null) {
-      _.defer(() => console.log({ token, supply: amount.toFixed() }));
       db.insert({ token, supply: amount.toFixed() }).into("token_supply").asCallback(callback);
     } else {
       const supply = oldSupply.supply.plus(amount);

--- a/src/setup/check-and-initialize-augur-db.ts
+++ b/src/setup/check-and-initialize-augur-db.ts
@@ -92,12 +92,12 @@ async function initializeNetworkInfo(db: Knex, augur: Augur): Promise<void> {
 
 async function checkAndUpdateContractUploadBlock(augur: Augur, networkId: string, databaseDir?: string): Promise<void> {
   const oldUploadBlockNumberFile = getUploadBlockPathFromNetworkId(networkId, databaseDir);
+  const dbPath = getDatabasePathFromNetworkId(networkId, DB_FILE, databaseDir);
   const currentUploadBlockNumber = augur.contracts.uploadBlockNumbers[augur.rpc.getNetworkID()];
-  if (existsSync(oldUploadBlockNumberFile)) {
+  if (existsSync(dbPath) && existsSync(oldUploadBlockNumberFile)) {
     const oldUploadBlockNumber = Number(await promisify(readFile)(oldUploadBlockNumberFile));
     if (currentUploadBlockNumber !== oldUploadBlockNumber) {
       console.log(`Deleting existing DB for this configuration as the upload block number is not equal: OLD: ${oldUploadBlockNumber} NEW: ${currentUploadBlockNumber}`);
-      const dbPath = getDatabasePathFromNetworkId(networkId, DB_FILE, databaseDir);
       renameDatabaseFile(networkId, dbPath);
     }
   }

--- a/src/setup/check-and-initialize-augur-db.ts
+++ b/src/setup/check-and-initialize-augur-db.ts
@@ -52,7 +52,7 @@ function createKnex(networkId: string, dbPath: string): Knex {
 }
 
 async function renameDatabaseFile(networkId: string, dbPath: string) {
-  const backupDbPath = getDatabasePathFromNetworkId(networkId, `backup-augur-%s-${new Date().getTime()}.db`, path.dirname(dbPath));
+  const backupDbPath = getDatabasePathFromNetworkId(networkId, `backup-augur-%s-%s-${new Date().getTime()}.db`, path.dirname(dbPath));
   logger.info(`Moving database ${dbPath} to ${backupDbPath}`);
   await promisify(rename)(dbPath, backupDbPath);
 }
@@ -92,17 +92,17 @@ async function initializeNetworkInfo(db: Knex, augur: Augur): Promise<void> {
 
 async function checkAndUpdateContractUploadBlock(augur: Augur, networkId: string, databaseDir?: string): Promise<void> {
   const oldUploadBlockNumberFile = getUploadBlockPathFromNetworkId(networkId, databaseDir);
-  let oldUploadBlockNumber = 0;
-  if (existsSync(oldUploadBlockNumberFile)) {
-    oldUploadBlockNumber = Number(await promisify(readFile)(oldUploadBlockNumberFile));
-  }
   const currentUploadBlockNumber = augur.contracts.uploadBlockNumbers[augur.rpc.getNetworkID()];
-  if (currentUploadBlockNumber !== oldUploadBlockNumber) {
-    console.log(`Deleting existing DB for this configuration as the upload block number is not equal: OLD: ${oldUploadBlockNumber} NEW: ${currentUploadBlockNumber}`);
-    const dbPath = getDatabasePathFromNetworkId(networkId, DB_FILE, databaseDir);
-    renameDatabaseFile(networkId, dbPath);
-    await promisify(writeFile)(oldUploadBlockNumberFile, currentUploadBlockNumber);
+  if (existsSync(oldUploadBlockNumberFile)) {
+    const oldUploadBlockNumber = Number(await promisify(readFile)(oldUploadBlockNumberFile));
+    if (currentUploadBlockNumber !== oldUploadBlockNumber) {
+      console.log(`Deleting existing DB for this configuration as the upload block number is not equal: OLD: ${oldUploadBlockNumber} NEW: ${currentUploadBlockNumber}`);
+      const dbPath = getDatabasePathFromNetworkId(networkId, DB_FILE, databaseDir);
+      renameDatabaseFile(networkId, dbPath);
+    }
   }
+  await promisify(writeFile)(oldUploadBlockNumberFile, currentUploadBlockNumber);
+
 }
 
 export async function renameBulkSyncDatabaseFile(networkId: string, databaseDir?: string) {

--- a/src/setup/check-and-initialize-augur-db.ts
+++ b/src/setup/check-and-initialize-augur-db.ts
@@ -102,7 +102,6 @@ async function checkAndUpdateContractUploadBlock(augur: Augur, networkId: string
     }
   }
   await promisify(writeFile)(oldUploadBlockNumberFile, currentUploadBlockNumber);
-
 }
 
 export async function renameBulkSyncDatabaseFile(networkId: string, databaseDir?: string) {


### PR DESCRIPTION
@nuevoalex whenever the DB was newly created, we were always comparing `0 != real-block-number`, and then attempting a rename on a file that didn't exist.