### PR TITLE
 volume based in ETH now

### DIFF
--- a/src/blockchain/log-processors/order-filled/update-volumetrics.ts
+++ b/src/blockchain/log-processors/order-filled/update-volumetrics.ts
@@ -75,10 +75,10 @@ export function updateVolumetrics(db: Knex, augur: Augur, category: string, mark
               if (!tradesRow) return callback(new Error(`trade not found, orderId: ${orderId}`));
               let amount = tradesRow.amount!;
               if (!isIncrease) amount = amount.negated();
-              const fullPrecisionPrice = augur.utils.convertDisplayPriceToOnChainPrice(tradesRow.price, minPrice, tickSize);
+              const price = tradesRow.price!.minus(minPrice);
               series({
-                market: (next) => incrementMarketVolume(db, marketId, amount, fullPrecisionPrice, next),
-                outcome: (next) => incrementOutcomeVolume(db, marketId, outcome, amount, fullPrecisionPrice, next),
+                market: (next) => incrementMarketVolume(db, marketId, amount, price, next),
+                outcome: (next) => incrementOutcomeVolume(db, marketId, outcome, amount, price, next),
                 marketLastTrade: (next) => setMarketLastTrade(db, marketId, blockNumber, next),
                 category: (next) => incrementCategoryPopularity(db, category, amount, next),
                 openInterest: (next) => updateOpenInterest(db, marketId, next),

--- a/test/unit/blockchain/log-processors/order-filled/index.js
+++ b/test/unit/blockchain/log-processors/order-filled/index.js
@@ -149,12 +149,12 @@ describe("blockchain/log-processors/order-filled", () => {
           tradeGroupId: "TRADE_GROUP_ID",
         }]);
         assert.deepEqual(records.markets, {
-          volume: new BigNumber("7000", 10),
+          volume: new BigNumber("0.7", 10),
           shareVolume: new BigNumber("1", 10),
           sharesOutstanding: new BigNumber("2", 10),
         });
         assert.deepEqual(records.outcomes, [
-          { price: new BigNumber("0.7", 10), volume: new BigNumber("7100", 10), shareVolume: new BigNumber("13.5", 10) },
+          { price: new BigNumber("0.7", 10), volume: new BigNumber("100.7", 10), shareVolume: new BigNumber("13.5", 10) },
           { price: new BigNumber("0.125", 10), volume: new BigNumber("100", 10), shareVolume: new BigNumber("12.5", 10) },
           { price: new BigNumber("0.125", 10), volume: new BigNumber("100", 10), shareVolume: new BigNumber("12.5", 10) },
           { price: new BigNumber("0.125", 10), volume: new BigNumber("100", 10), shareVolume: new BigNumber("12.5", 10) },
@@ -321,12 +321,12 @@ describe("blockchain/log-processors/order-filled", () => {
           tradeGroupId: "TRADE_GROUP_ID",
         }]);
         assert.deepEqual(records.markets, {
-          volume: new BigNumber("2800", 10),
+          volume: new BigNumber("0.28", 10),
           shareVolume: new BigNumber("0.4", 10),
           sharesOutstanding: new BigNumber("2", 10),
         });
         assert.deepEqual(records.outcomes, [
-          { price: new BigNumber("0.7", 10), volume: new BigNumber("2900", 10), shareVolume: new BigNumber("12.9", 10) },
+          { price: new BigNumber("0.7", 10), volume: new BigNumber("100.28", 10), shareVolume: new BigNumber("12.9", 10) },
           { price: new BigNumber("0.125", 10), volume: new BigNumber("100", 10), shareVolume: new BigNumber("12.5", 10) },
           { price: new BigNumber("0.125", 10), volume: new BigNumber("100", 10), shareVolume: new BigNumber("12.5", 10) },
           { price: new BigNumber("0.125", 10), volume: new BigNumber("100", 10), shareVolume: new BigNumber("12.5", 10) },


### PR DESCRIPTION
The previous logic was calculating volume by multiplying display share amount by on chain price. It should be using display price since the intended use case is for displaying the volume in ETH.

For scalar markets the display price have a different starting value for its range. We compensate for this by subtracting the minimum price in the range to get the actual price of 1 share in terms of ETH.

You can see how this change manifests in the tests giving us sensible and understandable values for volume. For example in the first test case a trade occurs for 1 display Share at price .7. The ETH volume here should be .7, not 7000 as it was previously.