### PR TITLE
remove case that undermines the actual check being done

### DIFF
--- a/src/blockchain/bulk-sync-augur-node-with-blockchain.ts
+++ b/src/blockchain/bulk-sync-augur-node-with-blockchain.ts
@@ -34,7 +34,7 @@ export async function bulkSyncAugurNodeWithBlockchain(db: Knex, augur: Augur): P
   } else {
     fromBlock = lastSyncBlockNumber == null ? uploadBlockNumber : lastSyncBlockNumber + 1;
   }
-  let handoffBlockNumber = highestBlockNumber - BLOCKSTREAM_HANDOFF_BLOCKS;
+  const handoffBlockNumber = highestBlockNumber - BLOCKSTREAM_HANDOFF_BLOCKS;
   if (handoffBlockNumber < fromBlock) {
     throw new Error(`Not enough blocks to start blockstream reliably, wait at least ${BLOCKSTREAM_HANDOFF_BLOCKS} from ${fromBlock}. Current Block: ${highestBlockNumber}`);
   }

--- a/src/blockchain/bulk-sync-augur-node-with-blockchain.ts
+++ b/src/blockchain/bulk-sync-augur-node-with-blockchain.ts
@@ -6,7 +6,7 @@ import { augurEmitter } from "../events";
 import { logger } from "../utils/logger";
 import { SubscriptionEventNames } from "../constants";
 
-const BLOCKSTREAM_HANDOFF_BLOCKS = 105;
+const BLOCKSTREAM_HANDOFF_BLOCKS = 5;
 let syncFinished = false;
 
 interface HighestBlockNumberRow {
@@ -36,11 +36,7 @@ export async function bulkSyncAugurNodeWithBlockchain(db: Knex, augur: Augur): P
   }
   let handoffBlockNumber = highestBlockNumber - BLOCKSTREAM_HANDOFF_BLOCKS;
   if (handoffBlockNumber < fromBlock) {
-    handoffBlockNumber = fromBlock;
-    if (handoffBlockNumber > highestBlockNumber) {
-      throw new Error(`Not enough blocks to start blockstream reliably, wait at least ${BLOCKSTREAM_HANDOFF_BLOCKS} from ${fromBlock}. Current Block: ${highestBlockNumber}`);
-    }
-    logger.warn(`Not leaving at least ${BLOCKSTREAM_HANDOFF_BLOCKS} between batch download and blockstream hand off during re-org can cause data quality issues`);
+    throw new Error(`Not enough blocks to start blockstream reliably, wait at least ${BLOCKSTREAM_HANDOFF_BLOCKS} from ${fromBlock}. Current Block: ${highestBlockNumber}`);
   }
   await promisify(downloadAugurLogs)(db, augur, fromBlock, handoffBlockNumber);
   setSyncFinished();


### PR DESCRIPTION
So for context this was resulting in an error during blockstream which would halt the stream but allow AN to continue running. That seems like a larger issue that should be addressed at some point. The visible results were that AN wasn't updating (obv) and other strange behavior in the UI like no time data being available (the original bug this issue was for).

What was occurring was that in the case the user was up to date but within the handoff block window this code would simply make them fetch just the block they last synced +1. This effectively gets rid of any handoff block window and also allows the sync to start at a block that doesn't yet exist in the case where the user's latest synced block is also the highest block. The later case is what was causing the error  that was manifesting where AN stalls and the UI shows weird data.

Since the handoff blocks number was basically being ignored previously I reduced it back to 5.