### PR TITLE
Default to maxRetries == 5 instead of 0 for ethrpc requests

### DIFF
--- a/src/runServer.ts
+++ b/src/runServer.ts
@@ -5,7 +5,16 @@ import { logger } from "./utils/logger";
 
 const networkName = process.argv[2] || "environment";
 const databaseDir = process.env.AUGUR_DATABASE_DIR;
-const maxRetries = process.env.MAX_REQUEST_RETRIES;
+
+// maxRetries is the maximum number of retries for retryable Ethereum RPC requests.
+// maxRetries is passed to augur.js's augur.connect() and then to ethrpc.connect(),
+// and is used internally by ethrpc for both HTTP and WS transports. When
+// an ethrpc request errors, a subset of errors are statically configured as
+// retryable, in which case ethrpc will opaquely re-insert the RPC request at
+// its internal queue head, such that augur.js (and augur-node) are ignorant
+// of requests that eventually succeed after N retries (where N < maxRetries).
+const maxRetries = process.env.MAX_REQUEST_RETRIES || 5; // default maxRetries to 5, because certain Ethereum RPC servers may frequently return transient errors and require non-zero ethrpc maxRetries to function sanely. Eg.  `geth --syncmode=light` frequently returns result "0x", signifying no data, for requests which should have data.
+
 const maxSystemRetries = process.env.MAX_SYSTEM_RETRIES;
 const propagationDelayWaitMillis = process.env.DELAY_WAIT_MILLIS;
 const networkConfig = NetworkConfiguration.create(networkName, false);


### PR DESCRIPTION
Fixes https://app.clubhouse.io/augur/story/17842/ethrpc-don-t-issue-disconnect-on-http-retry-unless-socket-error

maxRetries (configurable as env MAX_REQUEST_RETRIES) is the maximum number of
retries for retryable Ethereum RPC requests.  maxRetries is passed to augur.js's
augur.connect() and then to ethrpc.connect(), and is used internally by ethrpc
for both HTTP and WS transports. When an ethrpc request errors, a subset of
errors are statically configured as retryable, in which case ethrpc will
opaquely re-insert the RPC request at its internal queue head, such that
augur.js (and augur-node) are ignorant of requests that eventually succeed after
N retries (where N < maxRetries).

Default maxRetries to 5, because certain Ethereum RPC servers may frequently
return transient errors and require non-zero ethrpc maxRetries to function
sanely. Eg.  `geth --syncmode=light` frequently returns result "0x", signifying
no data, for requests which should have data.

(In the ethrpc library, the "0x" result is mapped into the ETH_CALL_FAILED
error with the text "eth_call returned no data (0x)".)

Testing done: I ran a locally modified ethrpc with debug logging and observed
retries succeeding. Anecdotally a few calls reached up to 4 attempts prior to
succeeding.