### PR TITLE
the block number given by rpc is static. Need to actually make request

### DIFF
--- a/src/blockchain/bulk-sync-augur-node-with-blockchain.ts
+++ b/src/blockchain/bulk-sync-augur-node-with-blockchain.ts
@@ -28,7 +28,7 @@ export async function bulkSyncAugurNodeWithBlockchain(db: Knex, augur: Augur): P
   const row: HighestBlockNumberRow|null = await db("blocks").max("blockNumber as highestBlockNumber").first();
   const lastSyncBlockNumber: number|null|undefined = row!.highestBlockNumber;
   const uploadBlockNumber: number = augur.contracts.uploadBlockNumbers[augur.rpc.getNetworkID()] || 0;
-  let highestBlockNumber: number = parseInt(augur.rpc.getCurrentBlock().number, 16);
+  let highestBlockNumber: number = await getHighestBlockNumber(augur);
   let fromBlock: number;
   if (uploadBlockNumber > highestBlockNumber) {
     logger.info(`Synchronization started at (${uploadBlockNumber}), which exceeds the current block from the ethereum node (${highestBlockNumber}), starting from 0 instead`);
@@ -37,15 +37,30 @@ export async function bulkSyncAugurNodeWithBlockchain(db: Knex, augur: Augur): P
     fromBlock = lastSyncBlockNumber == null ? uploadBlockNumber : lastSyncBlockNumber + 1;
   }
   let handoffBlockNumber = highestBlockNumber - BLOCKSTREAM_HANDOFF_BLOCKS;
+  let skipBulkDownload = false;
   while (handoffBlockNumber < fromBlock) {
+    skipBulkDownload = true;
     logger.warn(`Not enough blocks to start blockstream reliably, waiting at least ${BLOCKSTREAM_HANDOFF_BLOCKS} from ${fromBlock}. Current Block: ${highestBlockNumber}`);
     await delay(BLOCKSTREAM_HANDOFF_WAIT_TIME_MS);
-    highestBlockNumber = parseInt(augur.rpc.getCurrentBlock().number, 16);
+    highestBlockNumber = await getHighestBlockNumber(augur);
     handoffBlockNumber = highestBlockNumber - BLOCKSTREAM_HANDOFF_BLOCKS;
+  }
+  if (skipBulkDownload) {
+    logger.info(`Skipping batch load`);
+    return fromBlock;
   }
   await promisify(downloadAugurLogs)(db, augur, fromBlock, handoffBlockNumber);
   setSyncFinished();
   await db.insert({ highestBlockNumber }).into("blockchain_sync_history");
   logger.info(`Finished batch load from ${fromBlock} to ${handoffBlockNumber}`);
   return handoffBlockNumber;
+}
+
+async function getHighestBlockNumber(augur: Augur): Promise<number> {
+  return new Promise<number>((resolve, reject) => {
+    augur.rpc.eth.blockNumber("latest", (error, blockNumber: string) => {
+      if (error) reject("Couldn't get block number");
+      resolve(parseInt(blockNumber.toString(), 16));
+    });
+  });
 }


### PR DESCRIPTION
About that thing you said about how the call to get the block number curiously wasn't async...

Also the bit added about skipping bulk download: It occurred to me if we encounter this case its silly do do bulk download since we are so caught up we're only waiting for the benefit of blockstream. That and the ethrpc code doesn't actually update its known highest block before starting the bulk request which makes this case fail when we wait like this.