### PR TITLE
add check to make sure db file exists before renaming it

### DIFF
--- a/src/setup/check-and-initialize-augur-db.ts
+++ b/src/setup/check-and-initialize-augur-db.ts
@@ -101,7 +101,8 @@ async function checkAndUpdateContractUploadBlock(augur: Augur, networkId: string
 }
 
 export async function renameBulkSyncDatabaseFile(networkId: string, databaseDir?: string) {
-  return renameDatabaseFile(networkId, getDatabasePathFromNetworkId(networkId, DB_FILE, databaseDir));
+  const dbPath = getDatabasePathFromNetworkId(networkId, DB_FILE, databaseDir);
+  if (existsSync(dbPath)) return renameDatabaseFile(networkId, dbPath);
 }
 
 export async function createDbAndConnect(errorCallback: ErrorCallback|undefined, augur: Augur, network: ConnectOptions, databaseDir?: string): Promise<Knex> {


### PR DESCRIPTION
It was possible for the user to "reset database" then try to import warp file. This resulted in error b/c augur db file wouldn't exist. Needed to check before renaming.