### PR TITLE
Add 'yarn osx-copy-augur-app-db-to-augur-node-cli'

### DIFF
--- a/knexfile.js
+++ b/knexfile.js
@@ -55,7 +55,7 @@ module.exports = {
   "prod-test": {
     client: "sqlite3",
     connection: {
-      filename: "./augur-1-2.db",
+      filename: "./augur-1-3.db",
     },
     migrations: {
       directory: "./src/migrations",

--- a/scripts/osx-copy-augur-app-db-to-augur-node-cli
+++ b/scripts/osx-copy-augur-app-db-to-augur-node-cli
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# This script intended to be run with pwd at augur-node root.
+
+# This helper script will _overwrite_ your current augur-node cli database
+# with the DB from your OSX installed Augur App, and apply latest migrations
+# to the new cli db.
+
+# Why? In my workflow, my OSX installed Augur App is often at HEAD of
+# blockstream, but I frequently need to reset my augur-node CLI database.
+
+set -e;
+
+LATEST_DB=$(ls -t ~/Library/Application\ Support/augur/augur*db | head -1);
+
+echo -e "copying installed Augur App db to augur-node cli\nsrc db: $LATEST_DB";
+
+cp "$LATEST_DB" .;
+
+sqlite3 "$(basename "$LATEST_DB")" "update knex_migrations set name = substr(name,1, length(name)-2) || 'ts';";
+
+DEBUG=knex:tx yarn knex migrate:latest --env prod-test;

--- a/src/runServer.ts
+++ b/src/runServer.ts
@@ -47,6 +47,9 @@ function start(retries: number, config: ConnectOptions, databaseDir: string, isW
     }
     if (retries > 0) {
       logger.warn(err.message);
+      if (err.stack !== undefined) {
+        logger.warn(err.stack);
+      }
       retries--;
       augurNodeController.shutdown().catch(fatalError);
       setTimeout(() => start(retries, config, databaseDir, isWarpSync), 1000);


### PR DESCRIPTION
This helper script will _overwrite_ your current augur-node cli database
with the DB from your OSX installed Augur App, and apply latest migrations
to the new cli db.

Why? In my workflow, my OSX installed Augur App is often at HEAD of
blockstream, but I frequently need to reset my augur-node CLI database.