### PR TITLE
add getters for user and system db versions

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -14,7 +14,7 @@ import { logger } from "./utils/logger";
 import { LoggerInterface } from "./utils/logger/logger";
 import { BlockAndLogsQueue } from "./blockchain/block-and-logs-queue";
 
-import { getFileHash } from "./sync/file-operations";
+import { getFileHash, getHighestDbVersions } from "./sync/file-operations";
 import { BackupRestore } from "./sync/backup-restore";
 import { checkOrphanedOrders } from "./blockchain/check-orphaned-orders";
 
@@ -137,6 +137,21 @@ export class AugurNodeController {
 
   public addLogger(logger: LoggerInterface) {
     this.logger.addLogger(logger);
+  }
+
+  public systemDbVersion(): number {
+    return DB_VERSION;
+  }
+
+  public highestUserDbVersion(): number {
+    const version = 0;
+    try {
+      // only interested in mainnet databases
+      return getHighestDbVersions(this.databaseDir, "augur-1-");
+    } catch (err) {
+      if (this.errorCallback) this.errorCallback(err);
+    }
+    return version;
   }
 
   public clearLoggers() {

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -146,8 +146,9 @@ export class AugurNodeController {
   public highestUserDbVersion(): number {
     const version = 0;
     try {
-      // only interested in mainnet databases
-      return getHighestDbVersion(this.databaseDir, "augur-1-");
+      // default to mainnet if not currently connected to augur
+      const networkId = this.augur.rpc.getNetworkID() || "1";
+      return getHighestDbVersion(this.databaseDir, format("augur-%s-", networkId));
     } catch (err) {
       if (this.errorCallback) this.errorCallback(err);
     }

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -14,7 +14,7 @@ import { logger } from "./utils/logger";
 import { LoggerInterface } from "./utils/logger/logger";
 import { BlockAndLogsQueue } from "./blockchain/block-and-logs-queue";
 
-import { getFileHash, getHighestDbVersions } from "./sync/file-operations";
+import { getFileHash, getHighestDbVersion } from "./sync/file-operations";
 import { BackupRestore } from "./sync/backup-restore";
 import { checkOrphanedOrders } from "./blockchain/check-orphaned-orders";
 
@@ -147,7 +147,7 @@ export class AugurNodeController {
     const version = 0;
     try {
       // only interested in mainnet databases
-      return getHighestDbVersions(this.databaseDir, "augur-1-");
+      return getHighestDbVersion(this.databaseDir, "augur-1-");
     } catch (err) {
       if (this.errorCallback) this.errorCallback(err);
     }

--- a/src/sync/file-operations.ts
+++ b/src/sync/file-operations.ts
@@ -71,3 +71,20 @@ export function fileCompatible(filename: string, networkId: string, dbVersion: n
   const compSyncfile = format(DB_WARP_SYNC_FILE_ENDING, networkId, dbVersion);
   return filename.endsWith(compSyncfile);
 }
+
+export function getHighestDbVersions(directoryDir: string, dbFileName: string): number {
+  let version = 0;
+  const files = fs.readdirSync(directoryDir).filter((fn: string) => fn.startsWith(dbFileName));
+  if (files) {
+    _.each(files, (file) => {
+      const parts = file.split("-");
+      if (parts.length > 2) {
+        const fileVersion = parseInt(parts[2], 10);
+        if (fileVersion > version) {
+          version = fileVersion;
+        }
+      }
+    });
+  }
+  return version;
+}

--- a/src/sync/file-operations.ts
+++ b/src/sync/file-operations.ts
@@ -72,7 +72,7 @@ export function fileCompatible(filename: string, networkId: string, dbVersion: n
   return filename.endsWith(compSyncfile);
 }
 
-export function getHighestDbVersions(directoryDir: string, dbFileName: string): number {
+export function getHighestDbVersion(directoryDir: string, dbFileName: string): number {
   let version = 0;
   const files = fs.readdirSync(directoryDir).filter((fn: string) => fn.startsWith(dbFileName));
   if (files) {


### PR DESCRIPTION
add getters for system db version and user's highest db version based on scanning user's data directory for `augur-1-`. In this case we are only interested in mainnet databases. This give information to augur-app to inform user when they have to resync.