### PR TITLE
Fix short price unrealized realized

### DIFF
--- a/src/blockchain/log-processors/completesets.ts
+++ b/src/blockchain/log-processors/completesets.ts
@@ -41,7 +41,7 @@ export async function processCompleteSetsPurchasedOrSoldLog(augur: Augur, log: F
     if (log.eventName === "CompleteSetsPurchased") {
       await updateProfitLossBuyShares(db, marketId, log.account, numCompleteSets, Array.from(Array(numOutcomes).keys()), log.transactionHash);
     } else {
-      await updateProfitLossSellShares(db, marketId, numCompleteSets, log.account, Array.from(Array(numOutcomes).keys()), numCompleteSets, log.transactionHash);
+      await updateProfitLossSellShares(db, marketId, numCompleteSets, log.account, Array.from(Array(numOutcomes).keys()), numCompleteSets, log.transactionHash, log.blockNumber, log.transactionIndex, null);
     }
   };
 }

--- a/src/blockchain/log-processors/profit-loss/update-profit-loss.ts
+++ b/src/blockchain/log-processors/profit-loss/update-profit-loss.ts
@@ -122,6 +122,9 @@ export async function updateProfitLossSellShares(db: Knex, marketId: Address, nu
     const originalNumOwned = numShares.plus(numOwned);
     const totalOwned = originalNumOwned.plus(numEscrowed);
     const profit = oldProfit.plus(numShares.multipliedBy(sellPrice.minus(oldMoneySpent.dividedBy(totalOwned)))).toString();
+    if (transactionHash === "0x20ccd19fd73871642273b0658f1cc60e994034e302fc57adebd9b25718bab7fc") {
+      throw new Error(`XXX ${profit} ${sellPrice} ${oldMoneySpent} ${totalOwned}`);
+    }
     const moneySpent = oldMoneySpent.multipliedBy(numOwned.dividedBy(totalOwned)).toString();
     await db("profit_loss_timeseries")
       .update({ moneySpent, profit })

--- a/src/blockchain/log-processors/trading-proceeds-claimed.ts
+++ b/src/blockchain/log-processors/trading-proceeds-claimed.ts
@@ -42,7 +42,7 @@ export async function processTradingProceedsClaimedLog(augur: Augur, log: Format
     const numShares = new BigNumber(log.numShares, 10).dividedBy(tickSize).dividedBy(10 ** 18);
     const payoutTokens = new BigNumber(log.numPayoutTokens).dividedBy(10 ** 18);
 
-    await updateProfitLossSellShares(db, log.market, numShares, log.sender, [shareTokenOutcome.outcome], payoutTokens, log.transactionHash);
+    await updateProfitLossSellShares(db, log.market, numShares, log.sender, [shareTokenOutcome.outcome], payoutTokens, log.transactionHash, log.blockNumber, log.transactionIndex, shareTokenOutcome.outcome);
     augurEmitter.emit(SubscriptionEventNames.TradingProceedsClaimed, log);
   };
 }

--- a/src/server/getters/get-user-trading-positions.ts
+++ b/src/server/getters/get-user-trading-positions.ts
@@ -41,7 +41,7 @@ export async function getUserTradingPositions(db: Knex, augur: Augur, params: t.
 
   const endTime = params.endTime || Date.now() / 1000;
   const universeId = params.universe || (await queryUniverse(db, params.marketId!));
-  const { profit: profitsPerMarket, marketOutcomes: numOutcomesByMarket } = await getAllOutcomesProfitLoss(db, augur, {
+  const { profit: profitsPerMarket } = await getAllOutcomesProfitLoss(db, augur, {
     universe: universeId,
     account: params.account,
     marketId: params.marketId || null,
@@ -54,12 +54,6 @@ export async function getUserTradingPositions(db: Knex, augur: Augur, params: t.
 
   const positions = _.flatten(_.map(profitsPerMarket, (outcomePls: Array<Array<ProfitLossResult>>, marketId: string) => {
     const lastTimestampPls = _.last(outcomePls)!;
-    const numOutcomes = numOutcomesByMarket[marketId];
-    // For display purposes only we want 2 outcome markets to sum their realized profit since we hide the other outcome's information
-    if (numOutcomes !== 2 || lastTimestampPls.length < 2) return lastTimestampPls;
-    const totalRealized = lastTimestampPls[0].realized.plus(lastTimestampPls[1].realized);
-    lastTimestampPls[0].realized = totalRealized;
-    lastTimestampPls[1].realized = totalRealized;
     return lastTimestampPls;
   }));
 

--- a/test/unit/server/getters/get-profit-loss.js
+++ b/test/unit/server/getters/get-profit-loss.js
@@ -183,8 +183,8 @@ describe("server/getters/get-profit-loss#getProfitLossSummary", () => {
       position: "0.0003",
       realized: "54999999999.56442531007152770894",
       timestamp: 1534435013,
-      total: "54999999999.752826322444981005630002",
-      unrealized: "0.188401012373453296690002",
+      total: "54999999999.599826322444981005630002",
+      unrealized: "0.035401012373453296690002",
     });
     expect(deserialized["30"]).toMatchObject({
       averagePrice: "13.49831271091117218333",
@@ -192,8 +192,8 @@ describe("server/getters/get-profit-loss#getProfitLossSummary", () => {
       position: "0.0003",
       realized: "54999999999.56442531007152770894",
       timestamp: 1534435013,
-      total: "54999999999.752826322444981005630002",
-      unrealized: "0.188401012373453296690002",
+      total: "54999999999.599826322444981005630002",
+      unrealized: "0.035401012373453296690002",
     });
   });
 

--- a/test/unit/server/getters/get-user-trading-positions.js
+++ b/test/unit/server/getters/get-user-trading-positions.js
@@ -48,18 +48,18 @@ describe("server/getters/get-user-trading-positions", () => {
         unrealized: "0",
       },
       {
-        averagePrice: "13.49831271091117218333",
+        averagePrice: "386.50168728908882781667",
         cost: "0",
         marketId: "0x0000000000000000000000000000000000000ff1",
         netPosition: "-0.0006",
         outcome: 1,
         position: "0",
-        realized: "54999999999.56442531007152770894",
+        realized: "0",
         timestamp: 1534435013,
-        total: "0.188401012373453296690002",
+        total: "0.035401012373453296690002",
         totalPosition: "0",
         numEscrowed: "0",
-        unrealized: "0.188401012373453296690002",
+        unrealized: "0.035401012373453296690002",
       },
     ]);
   });
@@ -78,18 +78,18 @@ describe("server/getters/get-user-trading-positions", () => {
     });
 
     expect(userTradingPositions).toEqual([{
-      "averagePrice": "13.49831271091117218333",
+      "averagePrice": "386.50168728908882781667",
       "cost": "0",
       "marketId": "0x0000000000000000000000000000000000000ff1",
       "netPosition": "-0.0006",
       "outcome": 1,
       "position": "0",
-      "realized": "54999999999.56442531007152770894",
+      "realized": "0",
       "timestamp": 1534435013,
-      "total": "0.188401012373453296690002",
+      "total": "0.035401012373453296690002",
       "totalPosition": "0",
       "numEscrowed": "0",
-      "unrealized": "0.188401012373453296690002",
+      "unrealized": "0.035401012373453296690002",
     }]);
   });
 


### PR DESCRIPTION
We want:

 - Avg price to always be the price of the long position even when for a short
 - Unrealized to produce the correct value using this avg price
 - Realized Profit to be recorded relative to the outcome being traded, regardless of long or short
 - Scalar profit to properly be calculated when shorting

This set of changes should cover that. Due to these changes we could remove the realized profit summing as well since that will be covered by the new realized profit behavior