### PR TITLE
Support filtering by a list of ReportingState in getMarkets() API

### DIFF
--- a/src/server/getters/get-markets.ts
+++ b/src/server/getters/get-markets.ts
@@ -9,7 +9,7 @@ export const GetMarketsParamsSpecific = t.type({
   creator: t.union([t.string, t.null, t.undefined]),
   category: t.union([t.string, t.null, t.undefined]),
   search: t.union([t.string, t.null, t.undefined]),
-  reportingState: t.union([t.string, t.null, t.undefined]),
+  reportingState: t.union([t.string, t.null, t.undefined, t.array(t.string)]), // filter markets by ReportingState. If non-empty, expected to be a ReportingState or ReportingState[]
   feeWindow: t.union([t.string, t.null, t.undefined]),
   designatedReporter: t.union([t.string, t.null, t.undefined]),
   maxFee: t.union([t.number, t.null, t.undefined]),
@@ -31,7 +31,11 @@ export async function getMarkets(db: Knex, augur: {}, params: t.TypeOf<typeof Ge
   if (params.universe != null) query.where("universe", params.universe);
   if (params.creator != null) query.where({ marketCreator: params.creator });
   if (params.category != null) query.whereRaw("LOWER(markets.category) = ?", [params.category.toLowerCase()]);
-  if (params.reportingState != null) query.where("reportingState", params.reportingState);
+  if (typeof params.reportingState === "string") {
+    query.where("reportingState", params.reportingState);
+  } else if (params.reportingState instanceof Array) {
+    query.whereIn("reportingState", params.reportingState);
+  }
   if (params.feeWindow != null) query.where("feeWindow", params.feeWindow);
   if (params.designatedReporter != null) query.where("designatedReporter", params.designatedReporter);
   if (params.hasOrders != null && params.hasOrders) {

--- a/test/unit/server/getters/get-markets.js
+++ b/test/unit/server/getters/get-markets.js
@@ -322,6 +322,28 @@ describe("server/getters/get-markets", () => {
     },
   });
   runTest({
+    description: "get markets with multiple reporting states",
+    params: {
+      universe: "0x000000000000000000000000000000000000000b",
+      reportingState: [ReportingState.PRE_REPORTING, ReportingState.DESIGNATED_REPORTING],
+      sortBy: "volume",
+      isSortDescending: false,
+    },
+    assertions: (marketIds) => {
+      expect(marketIds).toEqual([
+        "0x0000000000000000000000000000000000000001",
+        "0x0000000000000000000000000000000000000002",
+        "0x0000000000000000000000000000000000000003",
+        "0x0000000000000000000000000000000000000222",
+        "0x0000000000000000000000000000000000000012",
+        "0x0000000000000000000000000000000000000014",
+        "0x0000000000000000000000000000000000000015",
+        "0x0000000000000000000000000000000000000016",
+        "0x0000000000000000000000000000000000000017",
+      ]);
+    },
+  });
+  runTest({
     description: "get all markets upcoming designated reporting by b0b",
     params: {
       universe: "0x000000000000000000000000000000000000000b",


### PR DESCRIPTION
Backwards compatible. Related to AugurProject/augur#812