### PR TITLE
Fix Postgres compatibility issues

### DIFF
--- a/src/migrations/20181009111121_profit_loss_timeseries.ts
+++ b/src/migrations/20181009111121_profit_loss_timeseries.ts
@@ -12,7 +12,7 @@ exports.up = async (knex: Knex): Promise<any> => {
       table.specificType("numEscrowed", "varchar(255) NOT NULL DEFAULT '0' CONSTRAINT nonnegativeNumEscrowed CHECK (ltrim(\"numEscrowed\", '-') = \"numEscrowed\")");
       table.string("profit", 255);
       table.specificType("timestamp", "integer NOT NULL CONSTRAINT nonnegativeTimestamp CHECK (\"timestamp\" >= 0)");
-      table.specificType("blockTransactionIndex", "integer NOT NULL CONSTRAINT nonnegativeBlockTransactionIndex CHECK (\"blockTransactionIndex\" >= 0)");
+      table.specificType("blockTransactionIndex", "varchar(255) NOT NULL DEFAULT '0' CONSTRAINT nonnegativeBlockTransactionIndex CHECK (ltrim(\"blockTransactionIndex\", '-') = \"blockTransactionIndex\")");
     });
   });
 };

--- a/src/migrations/20181009111121_profit_loss_timeseries.ts
+++ b/src/migrations/20181009111121_profit_loss_timeseries.ts
@@ -5,11 +5,11 @@ exports.up = async (knex: Knex): Promise<any> => {
     return knex.schema.createTable("profit_loss_timeseries", (table: Knex.CreateTableBuilder): void => {
       table.string("account", 42).notNullable();
       table.string("marketId", 42).notNullable();
-      table.specificType("outcome", "integer NOT NULL CONSTRAINT nonnegativeOutcome CHECK (outcome >= 0)");
+      table.specificType("outcome", "integer NOT NULL CONSTRAINT nonnegativeOutcome CHECK (\"outcome\" >= 0)");
       table.string("transactionHash", 66).notNullable();
-      table.specificType("moneySpent", "varchar(255) NOT NULL DEFAULT '0' CONSTRAINT nonnegativemoneySpent CHECK (ltrim(moneySpent, '-') = moneySpent)");
-      table.specificType("numOwned", "varchar(255) NOT NULL DEFAULT '0' CONSTRAINT nonnegativeNumOwned CHECK (ltrim(numOwned, '-') = numOwned)");
-      table.specificType("numEscrowed", "varchar(255) NOT NULL DEFAULT '0' CONSTRAINT nonnegativeNumEscrowed CHECK (ltrim(numEscrowed, '-') = numEscrowed)");
+      table.specificType("moneySpent", "varchar(255) NOT NULL DEFAULT '0' CONSTRAINT nonnegativemoneySpent CHECK (ltrim(\"moneySpent\", '-') = \"moneySpent\")");
+      table.specificType("numOwned", "varchar(255) NOT NULL DEFAULT '0' CONSTRAINT nonnegativeNumOwned CHECK (ltrim(\"numOwned\", '-') = \"numOwned\")");
+      table.specificType("numEscrowed", "varchar(255) NOT NULL DEFAULT '0' CONSTRAINT nonnegativeNumEscrowed CHECK (ltrim(\"numEscrowed\", '-') = \"numEscrowed\")");
       table.string("profit", 255);
       table.specificType("timestamp", "integer NOT NULL CONSTRAINT nonnegativeTimestamp CHECK (\"timestamp\" >= 0)");
       table.specificType("blockTransactionIndex", "integer NOT NULL CONSTRAINT nonnegativeBlockTransactionIndex CHECK (\"blockTransactionIndex\" >= 0)");


### PR DESCRIPTION

I wanted to connect augur-node to a Postgres database and after running `npm run start-clean`
I got this error "**...column "moneyspent" does not exist**":
```
Knex:warning - migration file "20190201161645_rebuild_volume_for_all_markets.ts" failed
Knex:warning - migration failed with error: create table "profit_loss_timeseries" ("account" varchar(42) not null, "marketId" varchar(42) not null, "outcome" integer NOT NULL CONSTRAINT nonnegativeOutcome CHECK (outcome >= 0), "transactionHash" varchar(66) not null, "moneySpent" varchar(255) NOT NULL DEFAULT '0' CONSTRAINT nonnegativemoneySpent CHECK (ltrim(moneySpent, '-') = moneySpent), "numOwned" varchar(255) NOT NULL DEFAULT '0' CONSTRAINT nonnegativeNumOwned CHECK (ltrim(numOwned, '-') = numOwned), "numEscrowed" varchar(255) NOT NULL DEFAULT '0' CONSTRAINT nonnegativeNumEscrowed CHECK (ltrim(numEscrowed, '-') = numEscrowed), "profit" varchar(255), "timestamp" integer NOT NULL CONSTRAINT nonnegativeTimestamp CHECK ("timestamp" >= 0), "blockTransactionIndex" integer NOT NULL CONSTRAINT nonnegativeBlockTransactionIndex CHECK ("blockTransactionIndex" >= 0)) - column "moneyspent" does not exist
```

I've discovered that there were missing some double quotation marks in the SQL. So I fixed that.

Then after a little while I got another error:
```
new block: 5938099, 1531212789 (Tue Jul 10 2018 08:53:09 GMT+0000 (Coordinated Universal Time))
Processing 12 logs
insert into "profit_loss_timeseries" ("account", "blockTransactionIndex", "marketId", "moneySpent", "numEscrowed", "numOwned", "outcome", "profit", "timestamp", "transactionHash") values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10) - value "5938099000003" is out of range for type integer
error: value "5938099000003" is out of range for type integer
    at Connection.parseE (/home/ubuntu/augur-node/node_modules/pg/lib/connection.js:546:11)
    at Connection.parseMessage (/home/ubuntu/augur-node/node_modules/pg/lib/connection.js:371:19)
    at Socket.<anonymous> (/home/ubuntu/augur-node/node_modules/pg/lib/connection.js:114:22)
    at Socket.emit (events.js:189:13)
    at Socket.EventEmitter.emit (domain.js:441:20)
    at addChunk (_stream_readable.js:284:12)
    at readableAddChunk (_stream_readable.js:265:11)
    at Socket.Readable.push (_stream_readable.js:220:10)
    at TCP.onStreamRead [as onread] (internal/stream_base_commons.js:94:17)
```

I've fix that one by changing `blockTransactionIndex`'s type from `integer` to `varchar(255)`