### PR TITLE
Remove tradegroup from completeSets

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "jest --runInBand",
     "test:integration": "mocha 'test/integration/**/*.ts'",
     "test:integration:docker": "docker-compose up --force-recreate --abort-on-container-exit",
-    "lint": "tslint -c tslint.json -p . -e src/version.ts && eslint test/unit",
+    "lint": "tslint -c tslint.json -p . -e src/version.ts && eslint  test/unit",
     "build:ts": "genversion --es6 --semi src/version.ts && tsc",
     "build": "npm-run-all lint build:ts",
     "watch": "genversion --es6 --semi src/version.ts && tsc -w",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "jest --runInBand",
     "test:integration": "mocha 'test/integration/**/*.ts'",
     "test:integration:docker": "docker-compose up --force-recreate --abort-on-container-exit",
-    "lint": "tslint -c tslint.json -p . -e src/version.ts && eslint  test/unit",
+    "lint": "tslint -c tslint.json -p . -e src/version.ts && eslint test/unit",
     "build:ts": "genversion --es6 --semi src/version.ts && tsc",
     "build": "npm-run-all lint build:ts",
     "watch": "genversion --es6 --semi src/version.ts && tsc -w",

--- a/src/blockchain/log-processors/completesets.ts
+++ b/src/blockchain/log-processors/completesets.ts
@@ -27,7 +27,6 @@ export async function processCompleteSetsPurchasedOrSoldLog(augur: Augur, log: F
       eventName: log.eventName,
       transactionHash: log.transactionHash,
       logIndex: log.logIndex,
-      tradeGroupId: log.tradeGroupId,
       numCompleteSets: numCompleteSets.toString(),
       numPurchasedOrSold: numCompleteSets.toString(),
     };

--- a/src/migrations/20190205102050_rm_complete_sets_trade_group_id.ts
+++ b/src/migrations/20190205102050_rm_complete_sets_trade_group_id.ts
@@ -1,0 +1,13 @@
+import * as Knex from "knex";
+
+exports.up = async (knex: Knex): Promise<any> => {
+  return knex.schema.table("completeSets", (table: Knex.CreateTableBuilder): void => {
+    table.dropColumns("tradeGroupId");
+  });
+};
+
+exports.down = async (knex: Knex): Promise<any> => {
+  return knex.schema.table("completeSets", (table: Knex.CreateTableBuilder): void => {
+    table.integer("tradeGroupId");
+  });
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -556,7 +556,6 @@ export interface CompleteSetsRow<BigNumberType> extends BaseTransactionRow {
   eventName: string;
   numPurchasedOrSold: BigNumberType;
   numCompleteSets: BigNumberType;
-  tradeGroupId: Bytes32|null;
 }
 
 export interface UICompleteSetsRow<BigNumberType> extends CompleteSetsRow<BigNumberType> {

--- a/test/unit/blockchain/log-processors/completesets.js
+++ b/test/unit/blockchain/log-processors/completesets.js
@@ -44,7 +44,6 @@ describe("blockchain/log-processors/completesets", () => {
         marketId: "0x0000000000000000000000000000000000000002",
         numCompleteSets: "2",
         numPurchasedOrSold: "2",
-        tradeGroupId: 12,
         transactionHash: "0x00000000000000000000000000000000deadbeef",
         universe: "0x0000000000000000000000000000000000000001",
       }]);


### PR DESCRIPTION
TradeGroups are a part of the order system, but not a part of CompleteSets directly.

Good thing, too, because integer is not a valid sqlite storage for a bytes32 value. Just get rid of it. 