### PR TITLE
Use new business definitions for Candlestick.volume/shareVolume

### DIFF
--- a/src/server/getters/get-market-price-candlesticks.ts
+++ b/src/server/getters/get-market-price-candlesticks.ts
@@ -4,6 +4,7 @@ import * as _ from "lodash";
 import { BigNumber } from "bignumber.js";
 import { ZERO } from "../../constants";
 import { OutcomeParam } from "../../types";
+import { volumeForTrade } from "../../blockchain/log-processors/order-filled/update-volumetrics";
 
 export const MarketPriceCandlesticksParams = t.type({
   marketId: t.string,
@@ -18,6 +19,10 @@ interface MarketPriceHistoryRow {
   outcome: number;
   price: BigNumber;
   amount: BigNumber;
+  numCreatorTokens: BigNumber;
+  numCreatorShares: BigNumber;
+  numFillerTokens: BigNumber;
+  numFillerShares: BigNumber;
 }
 
 export interface Candlestick {
@@ -26,8 +31,9 @@ export interface Candlestick {
   end: string;
   min: string;
   max: string;
-  volume: string;
-  tokenVolume: string;
+  volume: string; // volume in ETH for this Candlestick's time window, has same business definition as markets/outcomes.volume
+  shareVolume: string; // shareVolume in number of shares for this Candlestick's time window, has same business definition as markets/outcomes.shareVolume
+  tokenVolume: string; // TEMPORARY - this is a copy of Candlestick.shareVolume for the purposes of a backwards-compatible renaming of tokenVolume->shareVolume. The UI should change all references of Candlestick.tokenVolume to shareVolume and then this field can be removed.
 }
 
 export interface UICandlesticks {
@@ -40,28 +46,49 @@ function getPeriodStarttime(globalStarttime: number, periodStartime: number, per
 }
 
 export async function getMarketPriceCandlesticks(db: Knex, augur: {}, params: t.TypeOf<typeof MarketPriceCandlesticksParams>): Promise<UICandlesticks> {
+  const marketsRowPromise = db("markets").first("minPrice", "maxPrice").where({ marketId: params.marketId });
   const query = db.select([
     "trades.outcome",
     "trades.price",
     "trades.amount",
+    "trades.numCreatorShares",
+    "trades.numCreatorTokens",
+    "trades.numFillerTokens",
+    "trades.numFillerShares",
     "blocks.timestamp",
   ]).from("trades").join("blocks", "trades.blockNumber", "blocks.blockNumber").where("marketId", params.marketId);
   if (params.start != null) query.where("blocks.timestamp", ">=", params.start);
   if (params.end != null) query.where("blocks.timestamp", "<=", params.end);
   if (params.outcome) query.where("outcome", params.outcome);
+  const marketsRow: { minPrice: BigNumber, maxPrice: BigNumber } | undefined = await marketsRowPromise;
+  if (marketsRow === undefined) throw new Error(`No marketId for getMarketPriceCandlesticks: ${params.marketId}`);
   const tradesRows: Array<MarketPriceHistoryRow> = await query;
   const tradeRowsByOutcome = _.groupBy(tradesRows, "outcome");
   return _.mapValues(tradeRowsByOutcome, (outcomeTradeRows) => {
     const outcomeTradeRowsByPeriod = _.groupBy(outcomeTradeRows, (tradeRow) => getPeriodStarttime(params.start || 0, tradeRow.timestamp, params.period || 60));
     return _.map(outcomeTradeRowsByPeriod, (trades: Array<MarketPriceHistoryRow>, startTimestamp): Candlestick => {
-      return {
+      // TODO remove this partialCandlestick stuff and just return
+      // a Candlestick after the temporary Candlestick.tokenVolume
+      // is removed (see note on Candlestick.tokenVolume).
+      const partialCandlestick: Pick<Candlestick, Exclude<keyof Candlestick, "tokenVolume">> = { // this Pick/Exclude stuff just allows us to set the Candlestick.tokenVolume later, but in a typesafe way that prevents typos.
         startTimestamp: parseInt(startTimestamp, 10),
         start: _.minBy(trades, "timestamp")!.price.toString(),
         end: _.maxBy(trades, "timestamp")!.price.toString(),
         min: _.minBy(trades, "price")!.price.toString(),
         max: _.maxBy(trades, "price")!.price.toString(),
-        volume: _.reduce(trades, (totalAmount: BigNumber, tradeRow: MarketPriceHistoryRow) => totalAmount.plus(tradeRow.amount), ZERO).toString(),
-        tokenVolume: _.reduce(trades, (totalAmount: BigNumber, tradeRow: MarketPriceHistoryRow) => totalAmount.plus(tradeRow.amount.multipliedBy(tradeRow.price)), ZERO).toString(),
+        volume: _.reduce(trades, (totalVolume: BigNumber, tradeRow: MarketPriceHistoryRow) => totalVolume.plus(volumeForTrade({
+          marketMinPrice: marketsRow.minPrice,
+          marketMaxPrice: marketsRow.maxPrice,
+          numCreatorTokens: tradeRow.numCreatorTokens,
+          numCreatorShares: tradeRow.numCreatorShares,
+          numFillerTokens: tradeRow.numFillerTokens,
+          numFillerShares: tradeRow.numFillerShares,
+        })), ZERO).toString(),
+        shareVolume: _.reduce(trades, (totalShareVolume: BigNumber, tradeRow: MarketPriceHistoryRow) => totalShareVolume.plus(tradeRow.amount), ZERO).toString(), // the business definition of shareVolume should be the same as used with markets/outcomes.shareVolume (which currently is just summation of trades.amount)
+      };
+      return {
+        tokenVolume: partialCandlestick.shareVolume, // tokenVolume is temporary, see note on Candlestick.tokenVolume
+        ...partialCandlestick,
       };
     });
   });

--- a/test/unit/server/getters/get-market-price-candlesticks.js
+++ b/test/unit/server/getters/get-market-price-candlesticks.js
@@ -27,8 +27,9 @@ describe("server/getters/get-market-price-candlesticks", () => {
           min: "4.2",
           start: "5.5",
           startTimestamp: 1506474480,
-          volume: "0.3",
-          tokenVolume: "1.52",
+          volume: "2.1",
+          tokenVolume: "0.3",
+          shareVolume: "0.3",
         }],
       });
     },
@@ -48,8 +49,9 @@ describe("server/getters/get-market-price-candlesticks", () => {
           min: "5.5",
           start: "5.5",
           startTimestamp: 1506474493,
-          volume: "0.2",
-          tokenVolume: "1.1",
+          volume: "1.1",
+          tokenVolume: "0.2",
+          shareVolume: "0.2",
         },
         {
           end: "4.2",
@@ -57,8 +59,9 @@ describe("server/getters/get-market-price-candlesticks", () => {
           min: "4.2",
           start: "4.2",
           startTimestamp: 1506474513,
-          volume: "0.1",
-          tokenVolume: "0.42",
+          volume: "1",
+          tokenVolume: "0.1",
+          shareVolume: "0.1",
         }],
       });
     },
@@ -78,8 +81,9 @@ describe("server/getters/get-market-price-candlesticks", () => {
           min: "4.2",
           start: "5.5",
           startTimestamp: 1506474498,
-          volume: "0.3",
-          tokenVolume: "1.52",
+          volume: "2.1",
+          tokenVolume: "0.3",
+          shareVolume: "0.3",
         }],
       });
     },
@@ -87,7 +91,7 @@ describe("server/getters/get-market-price-candlesticks", () => {
   runTest({
     description: "market has no candlesticks",
     params: {
-      marketId: "0x0000000000000000000000000000000000001111",
+      marketId: "0x0000000000000000000000000000000000000ff1",
     },
     assertions: (marketPriceHistory) => {
       expect(marketPriceHistory).toEqual({});


### PR DESCRIPTION
`Candlestick.volume` uses new volume business definition via `volumeForTrade()`
to be consistent with markets/outcomes.volume.

Added `Candlestick.shareVolume`, a new name for `Candlestick.tokenVolume`
to be consistent with markets/outcomes.volume. `Candlestick.tokenVolume` should
be removed once UI updated to use `Candlestick.shareVolume`.

`Candlestick.shareVolume/tokenVolume` uses same business definition as
markets/outcomes.shareVolume.

Fixes AugurProject/augur#1002

# TODO

- [ ] create new issue to `s/tokenVolume/shareVolume` in UI

