### PR TITLE
need to guard against largestShort being undefined

### DIFF
--- a/src/server/getters/get-user-trading-positions.ts
+++ b/src/server/getters/get-user-trading-positions.ts
@@ -107,7 +107,7 @@ export async function getUserTradingPositions(db: Knex, augur: Augur, params: t.
   // Show outcomes with just a raw position if they have some quantity not accounted for via trades (e.g manual transfers)
   const rawPositionOnlyToShow = _.filter(rawPositionsMapping, (rawPosition) => {
     const largestShort = marketToLargestShort[rawPosition.marketId];
-    return !rawPosition.seen && largestShort.abs().lt(rawPosition.balance);
+    return !rawPosition.seen && largestShort && largestShort.abs().lt(rawPosition.balance);
   });
 
   const noPLPositions = _.map(rawPositionOnlyToShow, (rawPosition) => {


### PR DESCRIPTION
fixes https://github.com/AugurProject/augur/issues/1113

```
getter error: TypeError: Cannot read property 'abs' of undefined
at _.filter (/Users/bthaile/gitrepos/augur-node.git/src/server/getters/get-user-trading-positions.ts:116:46)
at /Users/bthaile/gitrepos/augur-node.git/node_modules/lodash/lodash.js:2935:13
at /Users/bthaile/gitrepos/augur-node.git/node_modules/lodash/lodash.js:4925:15
at baseForOwn (/Users/bthaile/gitrepos/augur-node.git/node_modules/lodash/lodash.js:3010:24)
at /Users/bthaile/gitrepos/augur-node.git/node_modules/lodash/lodash.js:4894:18
at baseFilter (/Users/bthaile/gitrepos/augur-node.git/node_modules/lodash/lodash.js:2934:7)
at Function.filter (/Users/bthaile/gitrepos/augur-node.git/node_modules/lodash/lodash.js:9173:14)
at /Users/bthaile/gitrepos/augur-node.git/src/server/getters/get-user-trading-positions.ts:114:35
at Generator.next ()
at fulfilled (/Users/bthaile/gitrepos/augur-node.git/src/server/getters/get-user-trading-positions.ts:4:58)
{"id":51,"jsonrpc":"2.0","method":"getMarketsInfo",
```

saw this error when getting user positions, doesn't happen every time, not sure the criteria.