### PR TITLE
augur-1192 ads platform activity stats to api

### DIFF
--- a/src/server/dispatch-json-rpc-request.ts
+++ b/src/server/dispatch-json-rpc-request.ts
@@ -33,6 +33,7 @@ import { getProfitLoss, GetProfitLossParams, getProfitLossSummary, GetProfitLoss
 import { getWinningBalance, WinningBalanceParams } from "./getters/get-winning-balance";
 import { getCategories, CategoriesParams } from "./getters/get-categories";
 import { getAccountTimeRangedStats, AccountTimeRangedStatsParams  } from "./getters/get-account-time-ranged-stats";
+import { getPlatformActivityStats, PlatformActivityStatsParams  } from "./getters/get-platform-activity-stats";
 
 type GetterFunction<T, R> = (db: Knex, augur: Augur, params: T) => Promise<R>;
 
@@ -58,6 +59,8 @@ export function dispatchJsonRpcRequest(db: Knex, request: JsonRpcRequest, augur:
       return dispatchResponse(getCategories, CategoriesParams.decode(request.params));
     case "getAccountTimeRangedStats":
       return dispatchResponse(getAccountTimeRangedStats, AccountTimeRangedStatsParams.decode(request.params));
+    case "getPlatformActivityStats":
+      return dispatchResponse(getPlatformActivityStats, PlatformActivityStatsParams.decode(request.params));
     case "getContractAddresses":
     case "getSyncData":
       return dispatchResponse(getSyncData, NoParams.decode({}));

--- a/src/server/getters/get-platform-activity-stats.ts
+++ b/src/server/getters/get-platform-activity-stats.ts
@@ -5,7 +5,7 @@ import { BigNumber } from "bignumber.js";
 
 export interface PlatformActivityResult {
   activeUsers: BigNumber;
-  BigNumberOfTrades: BigNumber;
+  numberOfTrades: BigNumber;
   openInterest: BigNumber;
   marketsCreated: BigNumber;
   volume: BigNumber;

--- a/src/server/getters/get-platform-activity-stats.ts
+++ b/src/server/getters/get-platform-activity-stats.ts
@@ -1,0 +1,34 @@
+import * as t from "io-ts";
+import * as Knex from "knex";
+import Augur from "augur.js";
+import { BigNumber } from "bignumber.js";
+
+export interface PlatformActivityResult {
+  activeUsers: BigNumber;
+  BigNumberOfTrades: BigNumber;
+  openInterest: BigNumber;
+  marketsCreated: BigNumber;
+  volume: BigNumber;
+  moneyAtStake: BigNumber;
+}
+
+export const PlatformActivityStatsParams = t.type({
+  universe: t.string,
+  endTime: t.union([t.number, t.null]),
+});
+export type PlatformActivityStatsParamsType = t.TypeOf<typeof PlatformActivityStatsParams>;
+
+export async function getPlatformActivityStats(db: Knex, augur: Augur, params: PlatformActivityStatsParamsType): Promise<PlatformActivityResult> {
+  const result: PlatformActivityResult = {
+    activeUsers:  new BigNumber(12, 10),
+    numberOfTrades:  new BigNumber(13, 10),
+    openInterest:  new BigNumber(14, 10),
+    marketsCreated:  new BigNumber(15, 10),
+    volume:  new BigNumber(16, 10),
+    moneyAtStake : new BigNumber(17, 10),
+  };
+
+  return new Promise<PlatformActivityResult>((resolve, reject) => {
+    resolve(result);
+  });
+}

--- a/test/unit/server/getters/get-platform-activity-stats.js
+++ b/test/unit/server/getters/get-platform-activity-stats.js
@@ -1,0 +1,33 @@
+const { setupTestDb, seedDb } = require("test.database");
+const { dispatchJsonRpcRequest } = require("src/server/dispatch-json-rpc-request");
+const { BigNumber } = require("bignumber.js");
+
+describe("server/getters/get-platform-activity-stats", () => {
+  let db;
+  beforeEach(async () => {
+    db = await setupTestDb().then(seedDb);
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  test("get platform activity stats", async () => {
+    const params = {
+      universe: "0x000000000000000000000000000000000000000b",
+      endTime: null,
+    };
+    const stats = await dispatchJsonRpcRequest(db, {
+      method: "getPlatformActivityStats",
+      params,
+    }, null);
+    expect(stats).toEqual({
+      "activeUsers": new BigNumber(12, 10),
+      "marketsCreated": new BigNumber(15, 10),
+      "moneyAtStake": new BigNumber(17, 10),
+      "numberOfTrades": new BigNumber(13, 10),
+      "openInterest": new BigNumber(14, 10),
+      "volume": new BigNumber(16, 10),
+    });
+  });
+});


### PR DESCRIPTION
#### Ads platform activity stats to the API

Provides
-Active Users
- number of Trades
- Open Interest
- Markets Created
- Volume
- Money at Stake
