### PR TITLE
Add P&L percents and financial math library

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "replace-in-file": "3.0.0",
     "tslint": "5.7.0",
     "tslint-eslint-rules": "4.1.1",
-    "typescript": "3.1.6"
+    "typescript": "3.3.3333"
   },
   "buildDependencies": [
     "typescript",

--- a/src/blockchain/log-processors/profit-loss/update-profit-loss.ts
+++ b/src/blockchain/log-processors/profit-loss/update-profit-loss.ts
@@ -5,7 +5,7 @@ import { Address, MarketsRow, PayoutNumerators, TradesRow } from "../../../types
 import { numTicksToTickSize } from "../../../utils/convert-fixed-point-to-decimal";
 import { getCurrentTime } from "../../process-block";
 import { FrozenFunds, FrozenFundsEvent, getFrozenFundsAfterEventForOneOutcome } from "./frozen-funds";
-import { getQuantityClosedFromTrade } from "../../../utils/financial-math";
+import { tradeGetQuantityClosed } from "../../../utils/financial-math";
 import { Tokens, Shares, Price } from "../../../utils/dimension-quantity";
 
 interface PayoutAndMarket<BigNumberType> extends PayoutNumerators<BigNumberType> {
@@ -94,7 +94,7 @@ export async function updateProfitLoss(db: Knex, marketId: Address, positionDelt
   // Adjust postion
   const position = oldPosition.plus(positionDelta);
 
-  const quantityClosed: Shares = getQuantityClosedFromTrade(oldPositionShares, positionDeltaShares);
+  const quantityClosed: Shares = tradeGetQuantityClosed(oldPositionShares, positionDeltaShares);
 
   // Adjust realized profit for amount of existing position sold
   if (!oldPosition.eq(ZERO) && oldPosition.s !== positionDelta.s) { // TODO this sign comparsion should use embedded design principle, eg. isPositionClose(oldPosition, positionDelta)
@@ -201,6 +201,7 @@ export async function updateProfitLossRemoveRow(db: Knex, transactionHash: strin
     .delete()
     .where({ transactionHash });
 }
+
 
 // makeFrozenFundsEvent() is a helper function of updateProfitLoss(). Passed
 // tradeData is associated data from the trade for which this user's profit and

--- a/src/blockchain/log-processors/profit-loss/update-profit-loss.ts
+++ b/src/blockchain/log-processors/profit-loss/update-profit-loss.ts
@@ -79,10 +79,10 @@ export async function updateProfitLoss(db: Knex, marketId: Address, positionDelt
     .where({ account, marketId, outcome })
     .orderByRaw(`"blockNumber" DESC, "logIndex" DESC`);
 
-  const netPosition: Shares = prevData ? new Shares(prevData.position) : Shares.sentinel;
-  const averagePerSharePriceToOpenPosition = prevData ? new Price(prevData.price) : Price.sentinel;
-  const realizedCost = prevData ? new Tokens(prevData.realizedCost) : Tokens.sentinel;
-  const realizedProfit = prevData ? new Tokens(prevData.profit) : Tokens.sentinel;
+  const netPosition: Shares = prevData ? new Shares(prevData.position) : Shares.ZERO;
+  const averagePerSharePriceToOpenPosition = prevData ? new Price(prevData.price) : Price.ZERO;
+  const realizedCost = prevData ? new Tokens(prevData.realizedCost) : Tokens.ZERO;
+  const realizedProfit = prevData ? new Tokens(prevData.profit) : Tokens.ZERO;
   const frozenFunds = prevData ? prevData.frozenFunds : ZERO;
 
   const nextNetPosition: Shares = tradeGetNextNetPosition({

--- a/src/blockchain/log-processors/profit-loss/update-profit-loss.ts
+++ b/src/blockchain/log-processors/profit-loss/update-profit-loss.ts
@@ -5,6 +5,8 @@ import { Address, MarketsRow, PayoutNumerators, TradesRow } from "../../../types
 import { numTicksToTickSize } from "../../../utils/convert-fixed-point-to-decimal";
 import { getCurrentTime } from "../../process-block";
 import { FrozenFunds, FrozenFundsEvent, getFrozenFundsAfterEventForOneOutcome } from "./frozen-funds";
+import { getQuantityClosedFromTrade } from "../../../utils/financial-math";
+import { Tokens, Shares, Price } from "../../../utils/dimension-quantity";
 
 interface PayoutAndMarket<BigNumberType> extends PayoutNumerators<BigNumberType> {
   minPrice: BigNumber;
@@ -12,10 +14,12 @@ interface PayoutAndMarket<BigNumberType> extends PayoutNumerators<BigNumberType>
   numTicks: BigNumber;
 }
 
+// TODO UpdateData should instead be Pick<ProfitLossTimeseries<BigNumber>, ...>
 interface UpdateData extends FrozenFunds {
   price: BigNumber;
   position: BigNumber;
   profit: BigNumber;
+  realizedCost: BigNumber;
 }
 
 export async function updateProfitLossClaimProceeds(db: Knex, marketId: Address, account: Address, transactionHash: string, blockNumber: number, logIndex: number): Promise<void> {
@@ -62,6 +66,8 @@ export async function updateProfitLossClaimProceeds(db: Knex, marketId: Address,
 export async function updateProfitLoss(db: Knex, marketId: Address, positionDelta: BigNumber, account: Address, outcome: number, price: BigNumber, transactionHash: string, blockNumber: number, logIndex: number, tradeData: undefined | Pick<TradesRow<BigNumber>, "orderType" | "creator" | "filler" | "price" | "numCreatorTokens" | "numCreatorShares" | "numFillerTokens" | "numFillerShares">): Promise<void> {
   if (positionDelta.eq(ZERO)) return;
 
+  const positionDeltaShares = new Shares(positionDelta);
+
   const timestamp = getCurrentTime();
 
   const marketsRow: Pick<MarketsRow<BigNumber>, "minPrice" | "maxPrice"> = await db("markets").first("minPrice", "maxPrice").where({ marketId });
@@ -69,31 +75,60 @@ export async function updateProfitLoss(db: Knex, marketId: Address, positionDelt
   price = price.minus(marketsRow.minPrice);
 
   const lastData: UpdateData = await db
-    .first(["price", "position", "profit", "frozenFunds"])
+    .first(["price", "position", "profit", "frozenFunds", "realizedCost"])
     .from("wcl_profit_loss_timeseries")
     .where({ account, marketId, outcome })
     .orderByRaw(`"blockNumber" DESC, "logIndex" DESC`);
 
+  // TODO standardize identifiers around prev/next?
+  const oldPositionShares: Shares = lastData ? new Shares(lastData.position) : Shares.sentinel;
   let oldPosition = lastData ? lastData.position : ZERO;
-  let oldPrice = lastData ? lastData.price : ZERO;
+  const constOldPrice = lastData ? new Price(lastData.price) : Price.sentinel; // TODO clean up
+  let oldPrice = constOldPrice.magnitude;
   const oldProfit = lastData ? lastData.profit : ZERO;
   const oldFrozenFunds = lastData ? lastData.frozenFunds : ZERO;
+  const prevRealizedCost = lastData ? new Tokens(lastData.realizedCost) : Tokens.sentinel;
 
   let profit = oldProfit;
 
   // Adjust postion
   const position = oldPosition.plus(positionDelta);
 
+  const quantityClosed: Shares = getQuantityClosedFromTrade(oldPositionShares, positionDeltaShares);
+
   // Adjust realized profit for amount of existing position sold
-  if (!oldPosition.eq(ZERO) && oldPosition.s !== positionDelta.s) {
-    const amountSold = BigNumber.min(oldPosition.abs(), positionDelta.abs());
-    const profitDelta = (oldPosition.lt(ZERO) ? oldPrice.minus(price) : price.minus(oldPrice)).multipliedBy(amountSold);
-    oldPosition = amountSold.gte(oldPosition.abs()) ? ZERO : oldPosition.plus(positionDelta);
-    positionDelta = oldPosition.eq(ZERO) ? position : ZERO;
+  if (!oldPosition.eq(ZERO) && oldPosition.s !== positionDelta.s) { // TODO this sign comparsion should use embedded design principle, eg. isPositionClose(oldPosition, positionDelta)
+    const profitDelta = (oldPosition.lt(ZERO) ? oldPrice.minus(price) : price.minus(oldPrice)).multipliedBy(quantityClosed.magnitude);
     profit = profit.plus(profitDelta);
+    // BEGIN SIMPLIFY1
+    oldPosition = quantityClosed.magnitude.gte(oldPosition.abs()) ? ZERO : oldPosition.plus(positionDelta); // set oldPosition to ZERO if position was entirely closed out this trade; otherwise set oldPosition to nextPosition
+    positionDelta = oldPosition.eq(ZERO) ? position : ZERO; // set positionDelta to nextPosition if position was entirely closed out this trade; otherwise set positionDelta to zero
     if (oldPosition.eq(ZERO)) {
       oldPrice = ZERO;
     }
+    // END SIMPLIFY1
+    /*
+      // TODO phase1: simplify above logic:
+      // TODO phase2: make everything maximally const
+        I think we can simplify this into a few cases:
+          open position
+          partially close position
+          fully close position
+          [fully close position, open position] = reverse position
+            --> reverse algorithm should be concatenation of these algorithms, not a new algorithm
+      // SIMPLIFY1 replacement code:
+      if (amountSold.gte(oldPosition.abs())) {
+        // position entirely closed out this trade
+        oldPosition = ZERO
+        positionDelta = nextPosition
+        oldPrice = ZERO; // ie. averagePrice resets each new position, is memoryless of previous positions
+      } else {
+        // position partially closed out this trade
+        oldPosition = nextPosition
+        positionDelta = ZERO
+      }
+      // invariant: oldPosition + position == nextPosition && one of them is ZERO
+    */
   }
 
   let newPrice = oldPrice;
@@ -101,6 +136,34 @@ export async function updateProfitLoss(db: Knex, marketId: Address, positionDelt
   // Adjust price for new position added
   if (!positionDelta.eq(ZERO)) {
     newPrice = (oldPrice.multipliedBy(oldPosition.abs())).plus(price.multipliedBy(positionDelta.abs())).dividedBy(position.abs());
+    /*
+      understanding this formula-
+      consider
+        oldPrice = 0.2
+        oldPosition = 1000
+        price = 0.1
+        positionDelta = -999
+        position = oldPosition + positionDelta = 1
+      then
+        // WRONG because position was partially closed out
+        (0.2*1000 + 0.1*999) / 1 = 99.9
+      but, if position was partially closed out this trade
+        (see SIMPLIFY11 replacement code above)
+        consolidating these:
+          if position entirely closed out this trade:
+            oldPosition = ZERO
+            positionDelta = nextPosition
+          otherwise
+            oldPosition = nextPosition
+            positionDelta = ZERO
+      then example becomes
+        // position not entirely closed out:
+        oldPosition = nextPosition = 1
+        positionDelta = 0
+      then
+        (0.2*1 + 0.1*0)/1 = 0.2 = (oldPrice*nextPosition + price*0)/nextPosition = oldPrice
+        // invariant: averagePrice = prevAveragePrice if position partially closed
+    */
   }
 
   const nextFrozenFunds = getFrozenFundsAfterEventForOneOutcome({
@@ -110,7 +173,11 @@ export async function updateProfitLoss(db: Knex, marketId: Address, positionDelt
     event: makeFrozenFundsEvent(account, profit.minus(oldProfit), marketsRow, tradeData),
   });
 
-  const insertData = {
+  const realizedCostDelta = quantityClosed.multipliedBy(constOldPrice).expect(Tokens); // TODO doc
+  const nextRealizedCost = prevRealizedCost.plus(realizedCostDelta); // TODO doc
+
+  // TODO strongly type as ProfitLossTimeseries<BigNumberType>; move ProfitLossTimeseries to types.ts and parameterize BigNumberType; unsure about ProfitLossTimeseries.minPrice, what does that do and why isn't it here?; this can even be ProfitLossTimeseries<string> so that compiler whines when I forget .toString()
+  const nextProfitLossTimeseries = {
     account,
     marketId,
     outcome,
@@ -122,9 +189,10 @@ export async function updateProfitLoss(db: Knex, marketId: Address, positionDelt
     blockNumber,
     logIndex,
     frozenFunds: nextFrozenFunds.frozenFunds.toString(),
+    realizedCost: nextRealizedCost.magnitude.toString(),
   };
 
-  await db.insert(insertData).into("wcl_profit_loss_timeseries");
+  await db.insert(nextProfitLossTimeseries).into("wcl_profit_loss_timeseries");
 }
 
 export async function updateProfitLossRemoveRow(db: Knex, transactionHash: string): Promise<void> {

--- a/src/migrations/20190201155650_wcl_profit_loss_timeseries.ts
+++ b/src/migrations/20190201155650_wcl_profit_loss_timeseries.ts
@@ -31,6 +31,7 @@ exports.up = async (knex: Knex): Promise<any> => {
     table.string("position", 42).notNullable();
     table.string("profit", 255).defaultTo("0");
     table.string("frozenFunds", 255).defaultTo("0");
+    table.string("realizedCost", 255).defaultTo("0");
     table.string("transactionHash", 66).notNullable();
     table.specificType("timestamp", "integer NOT NULL CONSTRAINT nonnegativeTimestamp CHECK (\"timestamp\" >= 0)");
     table.specificType("logIndex", "integer NOT NULL CONSTRAINT \"nonnegativelogIndex\" CHECK (\"logIndex\" >= 0)");

--- a/src/server/getters/get-profit-loss.ts
+++ b/src/server/getters/get-profit-loss.ts
@@ -151,17 +151,40 @@ export function sumProfitLossResults<T extends ProfitLossResult>(left: T, right:
   // TODO look in get-profit-loss for any other places that new fields need to be added
 
   const netPosition = leftPosition.plus(rightPosition);
+  const averagePrice = left.averagePrice.plus(right.averagePrice).dividedBy(2);
   const realized = left.realized.plus(right.realized);
   const unrealized = left.unrealized.plus(right.unrealized);
+  const unrealizedCost = left.unrealizedCost.plus(right.unrealizedCost);
+  const realizedCost = left.realizedCost.plus(right.realizedCost);
+  const totalCost = left.totalCost.plus(right.totalCost);
   const total = realized.plus(unrealized);
-  const averagePrice = left.averagePrice.plus(right.averagePrice).dividedBy(2); // TODO what is significance of dividing by 2 here?
+  const unrealizedPercent = positionGetUnrealizedProfitPercent({
+    unrealizedCost: new Tokens(unrealizedCost),
+    unrealizedProfit: new Tokens(unrealized),
+  });
+  const realizedPercent = positionGetRealizedProfitPercent({
+    realizedCost: new Tokens(realizedCost),
+    realizedProfit: new Tokens(realized),
+  });
+  const totalPercent = positionGetTotalProfitPercent({
+    totalCost: new Tokens(totalCost),
+    totalProfit: new Tokens(total),
+  });
+  const currentValue = left.currentValue.plus(right.currentValue);
 
   return Object.assign(_.clone(left), {
     netPosition,
+    averagePrice,
     realized,
     unrealized,
     total,
-    averagePrice,
+    unrealizedCost,
+    realizedCost,
+    totalCost,
+    unrealizedPercent: unrealizedPercent.magnitude,
+    realizedPercent: realizedPercent.magnitude,
+    totalPercent: totalPercent.magnitude,
+    currentValue,
   });
 }
 
@@ -467,10 +490,10 @@ export async function getProfitLossSummary(db: Knex, augur: Augur, params: GetPr
       unrealizedCost: startProfit.unrealizedCost.negated(),
       realizedCost: startProfit.realizedCost.negated(),
       totalCost: startProfit.totalCost.negated(),
-      realizedPercent: ZERO, // TODO ?? need to decide how this is handled in sumProfitLossResults()
-      unrealizedPercent: ZERO, // TODO ?? need to decide how this is handled in sumProfitLossResults()
-      totalPercent: ZERO, // TODO ?? need to decide how this is handled in sumProfitLossResults()
-      currentValue: startProfit.currentValue.negated(), // TODO
+      realizedPercent: startProfit.realizedPercent,
+      unrealizedPercent: startProfit.unrealizedPercent,
+      totalPercent: startProfit.totalPercent,
+      currentValue: startProfit.currentValue.negated(),
       frozenFunds: startProfit.frozenFunds.negated(),
     };
 

--- a/src/server/getters/get-profit-loss.ts
+++ b/src/server/getters/get-profit-loss.ts
@@ -61,13 +61,18 @@ export interface OutcomeValueTimeseries extends Timestamped {
 }
 
 export interface ProfitLossResult extends Timestamped, FrozenFunds {
+  // TODO doc fields
+  marketId: Address;
+  outcome: number;
   netPosition: BigNumber;
   averagePrice: BigNumber;
   realized: BigNumber;
   unrealized: BigNumber;
-  outcome: number;
-  marketId: Address;
   total: BigNumber;
+  realizedPercent: BigNumber;
+  unrealizedPercent: BigNumber;
+  totalPercent: BigNumber;
+  currentValue: BigNumber;
 }
 
 export interface ShortPosition {
@@ -219,6 +224,10 @@ function getProfitResultsForTimestamp(plsAtTimestamp: Array<ProfitLossTimeseries
       averagePrice,
       outcome,
       marketId,
+      realizedPercent: ZERO, // TODO
+      unrealizedPercent: ZERO, // TODO
+      totalPercent: ZERO, // TODO
+      currentValue: ZERO, // TODO
       frozenFunds: outcomePl.frozenFunds,
     };
   });
@@ -333,10 +342,14 @@ export async function getProfitLoss(db: Knex, augur: Augur, params: GetProfitLos
       cost: ZERO,
       averagePrice: ZERO,
       numEscrowed: ZERO,
-      totalPosition: ZERO,
+      totalPosition: ZERO, // TODO what is a totalPosition? and numEscrowed
       outcome: 0,
       netPosition: ZERO,
       marketId: "",
+      realizedPercent: ZERO,
+      unrealizedPercent: ZERO,
+      totalPercent: ZERO,
+      currentValue: ZERO, // TODO ??
       frozenFunds: ZERO,
     }));
   }
@@ -378,13 +391,17 @@ export async function getProfitLossSummary(db: Knex, augur: Augur, params: GetPr
 
     const negativeStartProfit: ProfitLossResult = {
       timestamp: startProfit.timestamp,
+      marketId: startProfit.marketId,
+      outcome: startProfit.outcome,
       netPosition: startProfit.netPosition.negated(),
+      averagePrice: startProfit.averagePrice,
       realized: startProfit.realized.negated(),
       unrealized: startProfit.unrealized.negated(),
       total: startProfit.total.negated(),
-      averagePrice: startProfit.averagePrice,
-      outcome: startProfit.outcome,
-      marketId: startProfit.marketId,
+      realizedPercent: ZERO, // TODO
+      unrealizedPercent: ZERO, // TODO
+      totalPercent: ZERO, // TODO
+      currentValue: ZERO, // TODO
       frozenFunds: startProfit.frozenFunds.negated(),
     };
 

--- a/src/server/getters/get-profit-loss.ts
+++ b/src/server/getters/get-profit-loss.ts
@@ -8,8 +8,8 @@ import { FrozenFunds } from "../../blockchain/log-processors/profit-loss/frozen-
 import { getCurrentTime } from "../../blockchain/process-block";
 import { ZERO } from "../../constants";
 import { Address } from "../../types";
-import { Percent, Price, Shares, Tokens } from "../../utils/dimension-quantity";
-import { positionGetCurrentValue, positionGetRealizedProfitPercent, positionGetTotalCost, positionGetTotalProfit, positionGetTotalProfitPercent, positionGetUnrealizedCost, positionGetUnrealizedProfit, positionGetUnrealizedProfitPercent } from "../../utils/financial-math";
+import { Price, Shares, Tokens } from "../../utils/dimension-quantity";
+import { getCurrentValue, getRealizedProfitPercent, getTotalCost, getTotalProfit, getTotalProfitPercent, getUnrealizedCost, getUnrealizedProfit, getUnrealizedProfitPercent } from "../../utils/financial-math";
 
 const DEFAULT_NUMBER_OF_BUCKETS = 30;
 
@@ -158,15 +158,15 @@ export function sumProfitLossResults<T extends ProfitLossResult>(left: T, right:
   const realizedCost = left.realizedCost.plus(right.realizedCost);
   const totalCost = left.totalCost.plus(right.totalCost);
   const total = realized.plus(unrealized);
-  const unrealizedPercent = positionGetUnrealizedProfitPercent({
+  const { unrealizedProfitPercent } = getUnrealizedProfitPercent({
     unrealizedCost: new Tokens(unrealizedCost),
     unrealizedProfit: new Tokens(unrealized),
   });
-  const realizedPercent = positionGetRealizedProfitPercent({
+  const { realizedProfitPercent } = getRealizedProfitPercent({
     realizedCost: new Tokens(realizedCost),
     realizedProfit: new Tokens(realized),
   });
-  const totalPercent = positionGetTotalProfitPercent({
+  const { totalProfitPercent } = getTotalProfitPercent({
     totalCost: new Tokens(totalCost),
     totalProfit: new Tokens(total),
   });
@@ -181,9 +181,9 @@ export function sumProfitLossResults<T extends ProfitLossResult>(left: T, right:
     unrealizedCost,
     realizedCost,
     totalCost,
-    unrealizedPercent: unrealizedPercent.magnitude,
-    realizedPercent: realizedPercent.magnitude,
-    totalPercent: totalPercent.magnitude,
+    unrealizedPercent: unrealizedProfitPercent.magnitude,
+    realizedPercent: realizedProfitPercent.magnitude,
+    totalPercent: totalProfitPercent.magnitude,
     currentValue,
   });
 }
@@ -240,7 +240,7 @@ function getProfitResultsForTimestamp(plsAtTimestamp: Array<ProfitLossTimeseries
     const realizedCost = new Tokens(outcomePl.realizedCost);
     const realizedProfit = new Tokens(outcomePl.profit);
     const outcome = outcomePl.outcome;
-    const averagePerSharePriceToOpenPosition = new Price(outcomePl.price);
+    const averagePricePerShareToOpenPosition = new Price(outcomePl.price);
     const minPrice = new Price(outcomePl.minPrice);
     const netPosition = new Shares(outcomePl.position);
     const frozenFunds = new Tokens(outcomePl.frozenFunds);
@@ -249,50 +249,50 @@ function getProfitResultsForTimestamp(plsAtTimestamp: Array<ProfitLossTimeseries
     // but, we want to display averagePrice; for scalar markets this means adding
     // minPrice. Eg. if a user paid an average price of 4.5 for a scalar market, but
     // the minPrice in that market is 3, we actually need to show 4.5+3=7.5 in the UI.
-    const averagePriceDisplay: Price = averagePerSharePriceToOpenPosition.plus(minPrice);
+    const averagePriceDisplay: Price = averagePricePerShareToOpenPosition.plus(minPrice);
 
     const lastPrice: Price | undefined = outcomeValuesAtTimestamp ? new Price(outcomeValuesAtTimestamp[outcome].value).minus(minPrice) : undefined;
 
-    const unrealizedCost: Tokens = positionGetUnrealizedCost({
+    const { unrealizedCost } = getUnrealizedCost({
       netPosition,
-      averagePerSharePriceToOpenPosition,
+      averagePricePerShareToOpenPosition,
       lastPrice,
     });
-    const unrealizedProfit: Tokens = positionGetUnrealizedProfit({
+    const { unrealizedProfit } = getUnrealizedProfit({
       netPosition,
-      averagePerSharePriceToOpenPosition,
+      averagePricePerShareToOpenPosition,
       lastPrice,
     });
-    const totalCost: Tokens = positionGetTotalCost({
+    const { totalCost } = getTotalCost({
       netPosition,
-      averagePerSharePriceToOpenPosition,
+      averagePricePerShareToOpenPosition,
       lastPrice,
       realizedCost,
     });
-    const positionCurrentValue: Tokens = positionGetCurrentValue({
+    const { currentValue } = getCurrentValue({
       netPosition,
-      averagePerSharePriceToOpenPosition,
+      averagePricePerShareToOpenPosition,
       lastPrice,
       frozenFunds,
     });
-    const totalProfit: Tokens = positionGetTotalProfit({
+    const { totalProfit } = getTotalProfit({
       netPosition,
-      averagePerSharePriceToOpenPosition,
+      averagePricePerShareToOpenPosition,
       lastPrice,
       realizedProfit,
     });
-    const realizedProfitPercent: Percent = positionGetRealizedProfitPercent({
+    const { realizedProfitPercent } = getRealizedProfitPercent({
       realizedCost,
       realizedProfit,
     });
-    const unrealizedProfitPercent: Percent = positionGetUnrealizedProfitPercent({
+    const { unrealizedProfitPercent } = getUnrealizedProfitPercent({
       netPosition,
-      averagePerSharePriceToOpenPosition,
+      averagePricePerShareToOpenPosition,
       lastPrice,
     });
-    const totalProfitPercent: Percent = positionGetTotalProfitPercent({
+    const { totalProfitPercent } = getTotalProfitPercent({
       netPosition,
-      averagePerSharePriceToOpenPosition,
+      averagePricePerShareToOpenPosition,
       lastPrice,
       realizedCost,
       realizedProfit,
@@ -313,7 +313,7 @@ function getProfitResultsForTimestamp(plsAtTimestamp: Array<ProfitLossTimeseries
       realizedPercent: realizedProfitPercent.magnitude,
       unrealizedPercent: unrealizedProfitPercent.magnitude,
       totalPercent: totalProfitPercent.magnitude,
-      currentValue: positionCurrentValue.magnitude,
+      currentValue: currentValue.magnitude,
       frozenFunds: frozenFunds.magnitude,
     };
   });

--- a/src/server/getters/get-profit-loss.ts
+++ b/src/server/getters/get-profit-loss.ts
@@ -60,19 +60,22 @@ export interface OutcomeValueTimeseries extends Timestamped {
   transactionHash: string;
 }
 
-export interface ProfitLossResult extends Timestamped, FrozenFunds {
-  // TODO doc fields
-  marketId: Address;
-  outcome: number;
-  netPosition: BigNumber;
-  averagePrice: BigNumber;
-  realized: BigNumber;
-  unrealized: BigNumber;
-  total: BigNumber;
-  realizedPercent: BigNumber;
-  unrealizedPercent: BigNumber;
-  totalPercent: BigNumber;
-  currentValue: BigNumber;
+// ProfitLossResult is the profit or loss result, at a particular point in
+// time, of a user's position in a single market outcome. ProfitLossResult
+// represents the total accumulation of history (for this market
+// outcome) as of an instantaneous point in time, like a balance sheet in
+// accounting. A user's "position" refers to the shares they have bought
+// ("long" position) or sold ("short" position) in this market outcome.
+export interface ProfitLossResult extends
+Timestamped, // profit and loss as of this timestamp
+FrozenFunds { // funds the user froze to be in this position (see FrozenFunds docs)
+  marketId: Address; // user's position is in this market
+  outcome: number; // user's position is in this market outcome
+  netPosition: BigNumber; // current quantity of shares in user's position for this market outcome. "net" position because if user bought 4 shares and sold 6 shares, netPosition would be -2 shares (ie. 4 - 6 = -2). User is "long" this market outcome (gets paid if this outcome occurs) if netPosition is positive. User is "short" this market outcome (gets paid if this outcome does not occur) if netPosition is negative
+  averagePrice: BigNumber; // average price per share user paid to be in this position
+  realized: BigNumber; // realized profit in tokens (eg. ETH) user already got from this market outcome. "realized" means the user bought/sold shares in such a way that the profit is already in the user's wallet
+  unrealized: BigNumber; // unrealized profit in tokens (eg. ETH) user could get from this market outcome. "unrealized" means the profit isn't in the user's wallet yet; the user could close the position to "realize" the profit, but instead is holding onto the shares. ProfitLossResult is currently not computed for each price change, so unrealized profit may be stale (not updated with latest share price).
+  total: BigNumber; // total profit in tokens (eg. ETH). Always equal to realized + unrealized
 }
 
 export interface ShortPosition {
@@ -130,6 +133,10 @@ export function bucketRangeByInterval(startTime: number, endTime: number, period
 export function sumProfitLossResults<T extends ProfitLossResult>(left: T, right: T): T {
   const leftPosition = new BigNumber(left.netPosition, 10);
   const rightPosition = new BigNumber(right.netPosition, 10);
+
+  // TODO new fields in sumProfitLossResults
+
+  // TODO look in get-profit-loss for any other places that new fields need to be added
 
   const netPosition = leftPosition.plus(rightPosition);
   const realized = left.realized.plus(right.realized);

--- a/src/server/getters/get-user-trading-positions.ts
+++ b/src/server/getters/get-user-trading-positions.ts
@@ -24,12 +24,22 @@ export const UserTradingPositionsParams = t.intersection([
   }),
 ]);
 
+// TODO doc per outcome
 export interface TradingPosition extends ProfitLossResult, FrozenFunds {
   position: string;
 }
 
+// TODO doc
+export interface MarketTradingPosition extends Pick<ProfitLossResult,
+"timestamp" | "marketId" | "realized" | "unrealized" | "total" | "realizedPercent" |
+"unrealizedPercent" | "totalPercent" | "currentValue"
+>, FrozenFunds {}
+
 export interface GetUserTradingPositionsResponse {
-  tradingPositions: Array<TradingPosition>;
+  tradingPositions: Array<TradingPosition>; // TODO doc
+  tradingPositionsPerMarket: { // TODO doc
+    [marketId: string]: MarketTradingPosition,
+  };
   frozenFundsTotal: FrozenFunds; // User's total frozen funds. See docs on FrozenFunds. This total includes market validity bonds in addition to sum of frozen funds for all market outcomes in which user has a position.
 }
 
@@ -128,6 +138,10 @@ export async function getUserTradingPositions(db: Knex, augur: Augur, params: t.
       unrealized: ZERO,
       total: ZERO,
       timestamp: 0,
+      realizedPercent: ZERO,
+      unrealizedPercent: ZERO,
+      totalPercent: ZERO,
+      currentValue: ZERO, // TODO ??
       frozenFunds: ZERO,
     };
   });
@@ -149,6 +163,32 @@ export async function getUserTradingPositions(db: Knex, augur: Augur, params: t.
 
   return {
     tradingPositions: positions,
+    tradingPositionsPerMarket: {
+      "0x1000000000000000000000000000000000000001": {
+        timestamp: 1551467992,
+        realized: ZERO,
+        unrealized: ZERO,
+        total: ZERO,
+        marketId: "0x1000000000000000000000000000000000000001",
+        realizedPercent: ZERO,
+        unrealizedPercent: ZERO,
+        totalPercent: ZERO,
+        currentValue: ZERO,
+        frozenFunds: ZERO,
+      },
+      "0x0000000000000000000000000000000000000002": {
+        timestamp: 1551467992,
+        realized: ZERO,
+        unrealized: ZERO,
+        total: ZERO,
+        marketId: "0x0000000000000000000000000000000000000002",
+        realizedPercent: ZERO,
+        unrealizedPercent: ZERO,
+        totalPercent: ZERO,
+        currentValue: ZERO,
+        frozenFunds: ZERO,
+      },
+    },
     frozenFundsTotal,
   };
 }

--- a/src/server/getters/get-user-trading-positions.ts
+++ b/src/server/getters/get-user-trading-positions.ts
@@ -26,20 +26,18 @@ export const UserTradingPositionsParams = t.intersection([
   }),
 ]);
 
-// TODO doc per outcome
 export interface TradingPosition extends ProfitLossResult, FrozenFunds {
   position: string;
 }
 
-// TODO doc
 export interface MarketTradingPosition extends Pick<ProfitLossResult,
   "timestamp" | "marketId" | "realized" | "unrealized" | "total" | "unrealizedCost" | "realizedCost" | "totalCost" | "realizedPercent" |
   "unrealizedPercent" | "totalPercent" | "currentValue"
   >, FrozenFunds { }
 
 export interface GetUserTradingPositionsResponse {
-  tradingPositions: Array<TradingPosition>; // TODO doc, including fact that unrealized is as of lastPrice and not timestamp
-  tradingPositionsPerMarket: { // TODO doc
+  tradingPositions: Array<TradingPosition>; // per-outcome TradingPosition, where unrealized profit is relative to an outcome's last price (as traded by anyone)
+  tradingPositionsPerMarket: { // per-market rollup of trading positions
     [marketId: string]: MarketTradingPosition,
   };
   frozenFundsTotal: FrozenFunds; // User's total frozen funds. See docs on FrozenFunds. This total includes market validity bonds in addition to sum of frozen funds for all market outcomes in which user has a position.
@@ -195,7 +193,6 @@ function aggregateTradingPositionsByMarket(tps: Array<TradingPosition>): { [mark
   return _.mapValues(tpsByMarketId, aggregateOneMarketTradingPositions);
 }
 
-// TODO doc, unit tests
 function aggregateOneMarketTradingPositions(tpsForOneMarketId: Array<TradingPosition>): MarketTradingPosition {
   // precondition: tpsForOneMarketId non-empty and all tpsForOneMarketId have same marketId
   const first = tpsForOneMarketId[0];

--- a/src/server/getters/get-user-trading-positions.ts
+++ b/src/server/getters/get-user-trading-positions.ts
@@ -7,8 +7,8 @@ import { FrozenFunds } from "../../blockchain/log-processors/profit-loss/frozen-
 import { BN_WEI_PER_ETHER, ZERO } from "../../constants";
 import { Address, MarketsRow, OutcomeParam, ReportingState, SortLimitParams } from "../../types";
 import { fixedPointToDecimal, numTicksToTickSize } from "../../utils/convert-fixed-point-to-decimal";
-import { Tokens, Percent } from "../../utils/dimension-quantity";
-import { positionGetRealizedProfitPercent, positionGetUnrealizedProfitPercent, positionGetTotalProfitPercent } from "../../utils/financial-math";
+import { Tokens } from "../../utils/dimension-quantity";
+import { getRealizedProfitPercent, getTotalProfitPercent, getUnrealizedProfitPercent } from "../../utils/financial-math";
 import { getAllOutcomesProfitLoss, ProfitLossResult } from "./get-profit-loss";
 
 export const UserTradingPositionsParamsSpecific = t.type({
@@ -211,23 +211,22 @@ function aggregateOneMarketTradingPositions(tpsForOneMarketId: Array<TradingPosi
     currentValue: sum(tpsForOneMarketId, (tp) => tp.currentValue),
     frozenFunds: sum(tpsForOneMarketId, (tp) => tp.frozenFunds),
   };
-  const realizedPercent: Percent = positionGetRealizedProfitPercent({
+  const { realizedProfitPercent } = getRealizedProfitPercent({
     realizedCost: new Tokens(partialMarketTradingPosition.realizedCost),
     realizedProfit: new Tokens(partialMarketTradingPosition.realized),
   });
-  const unrealizedPercent: Percent = positionGetUnrealizedProfitPercent({
+  const { unrealizedProfitPercent } = getUnrealizedProfitPercent({
     unrealizedCost: new Tokens(partialMarketTradingPosition.unrealizedCost),
     unrealizedProfit: new Tokens(partialMarketTradingPosition.unrealized),
   });
-  const totalPercent: Percent = positionGetTotalProfitPercent({
+  const { totalProfitPercent } = getTotalProfitPercent({
     totalCost: new Tokens(partialMarketTradingPosition.totalCost),
     totalProfit: new Tokens(partialMarketTradingPosition.total),
   });
-
   return {
-    realizedPercent: realizedPercent.magnitude,
-    unrealizedPercent: unrealizedPercent.magnitude,
-    totalPercent: totalPercent.magnitude,
+    realizedPercent: realizedProfitPercent.magnitude,
+    unrealizedPercent: unrealizedProfitPercent.magnitude,
+    totalPercent: totalProfitPercent.magnitude,
     ...partialMarketTradingPosition,
   };
 

--- a/src/server/post-process-database-results.ts
+++ b/src/server/post-process-database-results.ts
@@ -119,6 +119,7 @@ const whitelist: TableWhitelist = {
     price: true,
     profit: true,
     frozenFunds: true,
+    realizedCost: true,
   },
 };
 

--- a/src/utils/dimension-quantity.ts
+++ b/src/utils/dimension-quantity.ts
@@ -38,14 +38,22 @@ function isEqual(a: DimensionVector, b: DimensionVector): boolean {
 
 abstract class Quantity<T extends Quantity<T>> {
   // TODO an idea is to carry a history of dimension changes through operations so that when a dynamic dimension/type check fails, can give an explanation of where it came from
+  public readonly derivedConstructor: QuantityConstructor<T>;
   public readonly magnitude: BigNumber;
   public readonly dimension: DimensionVector;
-  public readonly derivedConstructor: QuantityConstructor<T>;
+  public readonly sign: -1 | 1;
   protected constructor(derivedConstructor: QuantityConstructor<T>, magnitude: BigNumber, dimension: DimensionVector) {
     // TODO allow magnitude to be a number for convenience
     this.derivedConstructor = derivedConstructor;
     this.magnitude = magnitude;
     this.dimension = dimension;
+    if (magnitude.s === -1) {
+      this.sign = -1;
+    } else if (magnitude.s === 1) {
+      this.sign = 1;
+    } else {
+      throw new Error(`expected BigNumber.s to be -1 or 1, was ${this.magnitude.s}`);
+    }
   }
   public multipliedBy(other: Percent): T;
   public multipliedBy(other: Scalar): T extends (Percent) ? Scalar : T;
@@ -65,9 +73,31 @@ abstract class Quantity<T extends Quantity<T>> {
     if (other instanceof Scalar || other instanceof Percent) {
       return new this.derivedConstructor(newMagnitude);
     }
-    const c = Object.assign({}, this.dimension);
-    Dimensions.forEach((u) => c[u] += other.dimension[u]);
-    return new UnverifiedQuantity(newMagnitude, c);
+    const newDimension = Object.assign({}, this.dimension);
+    Dimensions.forEach((u) => newDimension[u] += other.dimension[u]);
+    return new UnverifiedQuantity(newMagnitude, newDimension);
+  }
+  public dividedBy(other: Percent): T;
+  public dividedBy(other: Scalar): T extends (Percent) ? Scalar : T;
+  public dividedBy<B extends Quantity<B>>(other: B): T extends (Scalar | Percent) ? B : UnverifiedQuantity;
+  public dividedBy<B extends Quantity<B>>(other: B): B | T | UnverifiedQuantity {
+    const newMagnitude = this.magnitude.dividedBy(other.magnitude);
+    // TODO doc lack of symmtery between Scalar/Percent is why we need these special cases. Scalar is stronger than Percent because Scalar*Percent=Scalar
+    if (this instanceof Scalar && other instanceof Percent) {
+      return new this.derivedConstructor(newMagnitude);
+    }
+    if (other instanceof Scalar && this instanceof Percent) {
+      return new other.derivedConstructor(newMagnitude);
+    }
+    if (this instanceof Scalar || this instanceof Percent) {
+      return new other.derivedConstructor(newMagnitude);
+    }
+    if (other instanceof Scalar || other instanceof Percent) {
+      return new this.derivedConstructor(newMagnitude);
+    }
+    const newDimension = Object.assign({}, this.dimension);
+    Dimensions.forEach((u) => newDimension[u] -= other.dimension[u]);
+    return new UnverifiedQuantity(newMagnitude, newDimension);
   }
   public plus<B extends Quantity<B>>(other: B): T {
     if (!isEqual(this.dimension, other.dimension)) {
@@ -76,6 +106,28 @@ abstract class Quantity<T extends Quantity<T>> {
     const newMagnitude = this.magnitude.plus(other.magnitude);
     return new this.derivedConstructor(newMagnitude);
   }
+  public minus<B extends Quantity<B>>(other: B): T {
+    if (!isEqual(this.dimension, other.dimension)) {
+      throw new Error(`minus failed: expected dimensions to be equal, this=${this}, other=${other}`);
+    }
+    const newMagnitude = this.magnitude.minus(other.magnitude);
+    return new this.derivedConstructor(newMagnitude);
+  }
+  public isZero(): boolean {
+    return this.magnitude.isZero();
+  }
+  public abs(): T {
+    return new this.derivedConstructor(this.magnitude.abs());
+  }
+  // TODO generalized min(array)
+  public min<B extends Quantity<B>>(other: B): T {
+    if (!isEqual(this.dimension, other.dimension)) {
+      throw new Error(`min failed: expected dimensions to be equal, this=${this}, other=${other}`);
+    }
+    return new this.derivedConstructor(BigNumber.min(this.magnitude, other.magnitude));
+  }
+
+  // TODO there is a general pattern among some functions eg. plus/minus/min: ensure dimensions equal and then return derivedConstructor(some new magnitude); can probably simplify this code and it'd be worth it once more functions are added
 }
 
 interface QuantityConstructor<T extends Quantity<T>> {
@@ -96,34 +148,50 @@ class UnverifiedQuantity extends Quantity<UnverifiedQuantity> {
     }
     super(Copy, magnitude, dimension);
   }
-  // TODO consider renaming verify() to is() or shouldBe() or isIn()
-  public verify<T extends Quantity<T>>(vu: VerifiableQuantity<T>): T {
-    if (!isEqual(vu.sentinel.dimension, this.dimension)) {
-      throw new Error(`verify failed: dimensions not equal, expected=${vu}, actual=${this}`);
+  public expect<T extends Quantity<T>>(vq: VerifiableQuantity<T>): T {
+    if (!isEqual(vq.sentinel.dimension, this.dimension)) {
+      throw new Error(`expect failed: dimensions not equal, expected=${vq}, actual=${this}`);
     }
-    if (vu.isValidMagnitude !== undefined) {
-      const maybeErr = vu.isValidMagnitude(this.magnitude);
+    if (vq.isValidMagnitude !== undefined) {
+      const maybeErr = vq.isValidMagnitude(this.magnitude);
       if (maybeErr !== undefined) {
         // TODO wrap maybeErr with dimension context
         throw maybeErr;
       }
     }
-    return new vu(this.magnitude);
+    return new vq(this.magnitude);
   }
 }
 
+// ************************************************************************
+// **** specific units below here; a lot of this could be generated code
+
+// TODO rename sentinel to ZERO
+
+export function scalar(magnitude: number | BigNumber): Scalar {
+  if (typeof magnitude === "number") {
+    return new Scalar(new BigNumber(magnitude));
+  }
+  return new Scalar(magnitude);
+}
+const ScalarUnitDimension: DimensionVector = Object.freeze({
+  tokens: 0,
+  shares: 0,
+});
 export class Scalar extends Quantity<Scalar> {
   public static sentinel: Scalar = new Scalar(ZERO);
-  protected static readonly unitDimension: DimensionVector = {
-    tokens: 0,
-    shares: 0,
-  };
   public scalar: true; // this unique field makes this unit disjoint with other units so that you can't `a: Tokens = new Scalar()`
   constructor(magnitude: BigNumber) {
-    super(Scalar, magnitude, Scalar.unitDimension);
+    super(Scalar, magnitude, ScalarUnitDimension);
   }
 }
 
+export function percent(magnitude: number | BigNumber): Percent {
+  if (typeof magnitude === "number") {
+    return new Percent(new BigNumber(magnitude));
+  }
+  return new Percent(magnitude);
+}
 export class Percent extends Quantity<Percent> {
   public static sentinel: Percent = new Percent(ZERO);
   public static isValidMagnitude(magnitude: BigNumber): undefined | Error {
@@ -132,37 +200,63 @@ export class Percent extends Quantity<Percent> {
     }
     return;
   }
-  protected static readonly unitDimension: DimensionVector = {
-    tokens: 0,
-    shares: 0,
-  };
   public percent: true; // this unique field makes this unit disjoint with other units so that you can't `a: Tokens = new Percent2()`
   constructor(magnitude: BigNumber) {
-    super(Percent, magnitude, Percent.unitDimension);
+    super(Percent, magnitude, ScalarUnitDimension);
   }
 }
 
-class Tokens extends Quantity<Tokens> {
+export function tokens(magnitude: number | BigNumber): Tokens {
+  if (typeof magnitude === "number") {
+    return new Tokens(new BigNumber(magnitude));
+  }
+  return new Tokens(magnitude);
+}
+const TokensUnitDimension: DimensionVector = Object.freeze({
+  tokens: 1,
+  shares: 0,
+});
+export class Tokens extends Quantity<Tokens> {
   public static sentinel: Tokens = new Tokens(ZERO);
-  protected static readonly unitDimension: DimensionVector = {
-    tokens: 1,
-    shares: 0,
-  };
   public tokens: true; // this unique field makes this unit disjoint with other units so that you can't `a: Tokens = new Scalar()`
   constructor(magnitude: BigNumber) {
-    super(Tokens, magnitude, Tokens.unitDimension);
+    super(Tokens, magnitude, TokensUnitDimension);
   }
 }
 
-class Shares extends Quantity<Shares> {
+export function shares(magnitude: number | BigNumber): Shares {
+  if (typeof magnitude === "number") {
+    return new Shares(new BigNumber(magnitude));
+  }
+  return new Shares(magnitude);
+}
+const SharesUnitDimension: DimensionVector = Object.freeze({
+  tokens: 0,
+  shares: 1,
+});
+export class Shares extends Quantity<Shares> {
   public static sentinel: Shares = new Shares(ZERO);
-  protected static readonly unitDimension: DimensionVector = {
-    tokens: 0,
-    shares: 1,
-  };
   public shares: true; // this unique field makes this unit disjoint with other units so that you can't `a: Shares = new Scalar()`
   constructor(magnitude: BigNumber) {
-    super(Shares, magnitude, Shares.unitDimension);
+    super(Shares, magnitude, SharesUnitDimension);
+  }
+}
+
+export function price(magnitude: number | BigNumber): Price {
+  if (typeof magnitude === "number") {
+    return new Price(new BigNumber(magnitude));
+  }
+  return new Price(magnitude);
+}
+const PriceUnitDimension: DimensionVector = Object.freeze({
+  tokens: 1,
+  shares: -1,
+});
+export class Price extends Quantity<Price> {
+  public static sentinel: Price = new Price(ZERO);
+  public price: true; // this unique field makes this unit disjoint with other units so that you can't `a: Price = new Scalar()`
+  constructor(magnitude: BigNumber) {
+    super(Price, magnitude, PriceUnitDimension);
   }
 }
 
@@ -192,4 +286,9 @@ const uq2 = new UnverifiedQuantity(ONE, {
   shares: 0,
 });
 
-const t8: Tokens = uq2.verify(Tokens);
+const t8: Tokens = uq2.expect(Tokens);
+
+const pr: Price = new UnverifiedQuantity(ONE, {
+  tokens: 1,
+  shares: -1,
+}).expect(Price);

--- a/src/utils/dimension-quantity.ts
+++ b/src/utils/dimension-quantity.ts
@@ -3,6 +3,9 @@ import { BigNumber } from "bignumber.js";
 const ZERO = new BigNumber(0);
 const ONE = new BigNumber(1);
 
+// TODO <BigNumberType>
+// TODO ETH/attoETH/erc20
+// TODO can this be assemblyscript?
 // TODO support derivation for non-unit quantity types, similar to safe-units. Eg. `export const Price = Tokens.dividedBy(Shares)`
 // TODO can we create something like NonNegative<T extends Quantity<T>> and use isValidMagnitude?
 
@@ -319,3 +322,5 @@ const pr: Price = new UnverifiedQuantity(ONE, {
   tokens: 1,
   shares: -1,
 }).expect(Price);
+
+const shouldBePrice: Price = t.dividedBy(new Shares(ONE)).expect(Price);

--- a/src/utils/dimension-quantity.ts
+++ b/src/utils/dimension-quantity.ts
@@ -157,7 +157,7 @@ interface QuantityConstructor<T extends Quantity<T>> {
 }
 
 interface VerifiableQuantity<T extends Quantity<T>> extends QuantityConstructor<T> {
-  sentinel: T;
+  ZERO: T;
   isValidMagnitude?(magnitude: BigNumber): undefined | Error; // TODO doc
 }
 
@@ -191,7 +191,7 @@ class UnverifiedQuantity extends Quantity<UnverifiedQuantity> {
       "expect failed: dimensions not equal, expected Price and got { tokens: 1, shares: -5 }"
   */
   public expect<T extends Quantity<T>>(vq: VerifiableQuantity<T>): T {
-    if (!isEqual(vq.sentinel.dimension, this.dimension)) {
+    if (!isEqual(vq.ZERO.dimension, this.dimension)) {
       throw new Error(`expect failed: dimensions not equal, expected=${vq}, actual=${this}`);
     }
     if (vq.isValidMagnitude !== undefined) {
@@ -208,8 +208,6 @@ class UnverifiedQuantity extends Quantity<UnverifiedQuantity> {
 // ************************************************************************
 // **** specific units below here; a lot of this could be generated code
 
-// TODO rename sentinel to ZERO; add ONE
-
 export function scalar(magnitude: number | BigNumber): Scalar {
   if (typeof magnitude === "number") {
     return new Scalar(new BigNumber(magnitude));
@@ -221,8 +219,7 @@ const ScalarUnitDimension: DimensionVector = Object.freeze({
   shares: 0,
 });
 export class Scalar extends Quantity<Scalar> {
-  public static sentinel: Scalar = new Scalar(ZERO);
-  public static ONE: Scalar = new Scalar(ONE);
+  public static ZERO: Scalar = new Scalar(ZERO);
   public scalar: true; // this unique field makes this unit disjoint with other units so that you can't `a: Tokens = new Scalar()`
   constructor(magnitude: BigNumber) {
     super(Scalar, magnitude, ScalarUnitDimension);
@@ -236,7 +233,7 @@ export function percent(magnitude: number | BigNumber): Percent {
   return new Percent(magnitude);
 }
 export class Percent extends Quantity<Percent> {
-  public static sentinel: Percent = new Percent(ZERO);
+  public static ZERO: Percent = new Percent(ZERO);
   public percent: true; // this unique field makes this unit disjoint with other units so that you can't `a: Tokens = new Percent2()`
   constructor(magnitude: BigNumber) {
     super(Percent, magnitude, ScalarUnitDimension);
@@ -254,7 +251,7 @@ const TokensUnitDimension: DimensionVector = Object.freeze({
   shares: 0,
 });
 export class Tokens extends Quantity<Tokens> {
-  public static sentinel: Tokens = new Tokens(ZERO);
+  public static ZERO: Tokens = new Tokens(ZERO);
   public tokens: true; // this unique field makes this unit disjoint with other units so that you can't `a: Tokens = new Scalar()`
   constructor(magnitude: BigNumber) {
     super(Tokens, magnitude, TokensUnitDimension);
@@ -272,7 +269,7 @@ const SharesUnitDimension: DimensionVector = Object.freeze({
   shares: 1,
 });
 export class Shares extends Quantity<Shares> {
-  public static sentinel: Shares = new Shares(ZERO);
+  public static ZERO: Shares = new Shares(ZERO);
   public shares: true; // this unique field makes this unit disjoint with other units so that you can't `a: Shares = new Scalar()`
   constructor(magnitude: BigNumber) {
     super(Shares, magnitude, SharesUnitDimension);
@@ -290,7 +287,7 @@ const PriceUnitDimension: DimensionVector = Object.freeze({
   shares: -1,
 });
 export class Price extends Quantity<Price> {
-  public static sentinel: Price = new Price(ZERO);
+  public static ZERO: Price = new Price(ZERO);
   public price: true; // this unique field makes this unit disjoint with other units so that you can't `a: Price = new Scalar()`
   constructor(magnitude: BigNumber) {
     super(Price, magnitude, PriceUnitDimension);

--- a/src/utils/dimension-quantity.ts
+++ b/src/utils/dimension-quantity.ts
@@ -4,28 +4,15 @@ const ZERO = new BigNumber(0);
 const ONE = new BigNumber(1);
 
 // TODO toString() method "20 tokens", "20 tokens/share", "20 tokens^2*shares^-3"
-// TODO <BigNumberType>
 // TODO ETH/attoETH/erc20
-// TODO can this be assemblyscript?
 // TODO support derivation for non-unit quantity types, similar to safe-units. Eg. `export const Price = Tokens.dividedBy(Shares)`
 // TODO can we create something like NonNegative<T extends Quantity<T>> and use isValidMagnitude?
 
-/*
-// TODO update outdated doc
-
-Idea here is
-  1. centralize financial formulas instead of inlining them elsewhere, especially to ensure formula correctness
-  2. use domain-specific types like `Ether` instead of BigNumber, to help ensure formula correctness
-
-Long term vision might be to split into two separate libraries:
-  1. domain-specific types for reuse in other projects
-  2. augur-math library for use in other Augur projects
-
-For domain-specific types like `Ether`, we'd prefer compile-time type safety, but
-settle for runtime checks. https://github.com/jscheiny/safe-units is an excellent
-project that provides compile-time type safety and could be extended to include Ether,
-but unfortunately is impractical due to increasing project build time by _minutes_.
-*/
+// For domain-specific types like `Ether`, we'd prefer compile-time type
+// safety, but settle for runtime checks. https://github.com/jscheiny/safe-units
+// is an excellent project that provides compile-time type safety
+// and could be extended to include Ether, but unfortunately is
+// impractical due to extremely long compile times (minutes).
 
 type Dimension = "tokens" | "shares";
 const Dimensions: Array<Dimension> = ["tokens", "shares"];
@@ -51,7 +38,6 @@ abstract class Quantity<T extends Quantity<T>> {
   public readonly dimension: DimensionVector;
   public readonly sign: -1 | 1;
   protected constructor(derivedConstructor: QuantityConstructor<T>, magnitude: BigNumber, dimension: DimensionVector) {
-    // TODO allow magnitude to be a number for convenience
     this.derivedConstructor = derivedConstructor;
     this.magnitude = magnitude;
     this.dimension = dimension;

--- a/src/utils/dimension-quantity.ts
+++ b/src/utils/dimension-quantity.ts
@@ -3,6 +3,7 @@ import { BigNumber } from "bignumber.js";
 const ZERO = new BigNumber(0);
 const ONE = new BigNumber(1);
 
+// TODO toString() method "20 tokens", "20 tokens/share", "20 tokens^2*shares^-3"
 // TODO <BigNumberType>
 // TODO ETH/attoETH/erc20
 // TODO can this be assemblyscript?
@@ -130,6 +131,12 @@ abstract class Quantity<T extends Quantity<T>> {
       throw new Error(`lt failed: expected dimensions to be equal, this=${this}, other=${other}`);
     }
     return this.magnitude.lt(other.magnitude);
+  }
+  public gt<B extends Quantity<B>>(other: B): boolean {
+    if (!isEqual(this.dimension, other.dimension)) {
+      throw new Error(`gt failed: expected dimensions to be equal, this=${this}, other=${other}`);
+    }
+    return this.magnitude.gt(other.magnitude);
   }
   public abs(): T {
     return new this.derivedConstructor(this.magnitude.abs());

--- a/src/utils/dimension-quantity.ts
+++ b/src/utils/dimension-quantity.ts
@@ -1,0 +1,195 @@
+import { BigNumber } from "bignumber.js";
+
+const ZERO = new BigNumber(0);
+const ONE = new BigNumber(1);
+
+/*
+// TODO update outdated doc
+
+Idea here is
+  1. centralize financial formulas instead of inlining them elsewhere, especially to ensure formula correctness
+  2. use domain-specific types like `Ether` instead of BigNumber, to help ensure formula correctness
+
+Long term vision might be to split into two separate libraries:
+  1. domain-specific types for reuse in other projects
+  2. augur-math library for use in other Augur projects
+
+For domain-specific types like `Ether`, we'd prefer compile-time type safety, but
+settle for runtime checks. https://github.com/jscheiny/safe-units is an excellent
+project that provides compile-time type safety and could be extended to include Ether,
+but unfortunately is impractical due to increasing project build time by _minutes_.
+*/
+
+type Dimension = "tokens" | "shares";
+const Dimensions: Array<Dimension> = ["tokens", "shares"];
+
+type DimensionVector = {
+  [k in Dimension]: number;
+};
+
+function isEqual(a: DimensionVector, b: DimensionVector): boolean {
+  for (const d of Dimensions) {
+    if (a[d] !== b[d]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+abstract class Quantity<T extends Quantity<T>> {
+  // TODO an idea is to carry a history of dimension changes through operations so that when a dynamic dimension/type check fails, can give an explanation of where it came from
+  public readonly magnitude: BigNumber;
+  public readonly dimension: DimensionVector;
+  public readonly derivedConstructor: QuantityConstructor<T>;
+  protected constructor(derivedConstructor: QuantityConstructor<T>, magnitude: BigNumber, dimension: DimensionVector) {
+    // TODO allow magnitude to be a number for convenience
+    this.derivedConstructor = derivedConstructor;
+    this.magnitude = magnitude;
+    this.dimension = dimension;
+  }
+  public multipliedBy(other: Percent): T;
+  public multipliedBy(other: Scalar): T extends (Percent) ? Scalar : T;
+  public multipliedBy<B extends Quantity<B>>(other: B): T extends (Scalar | Percent) ? B : UnverifiedQuantity;
+  public multipliedBy<B extends Quantity<B>>(other: B): B | T | UnverifiedQuantity {
+    const newMagnitude = this.magnitude.multipliedBy(other.magnitude);
+    // TODO doc lack of symmtery between Scalar/Percent is why we need these special cases. Scalar is stronger than Percent because Scalar*Percent=Scalar
+    if (this instanceof Scalar && other instanceof Percent) {
+      return new this.derivedConstructor(newMagnitude);
+    }
+    if (other instanceof Scalar && this instanceof Percent) {
+      return new other.derivedConstructor(newMagnitude);
+    }
+    if (this instanceof Scalar || this instanceof Percent) {
+      return new other.derivedConstructor(newMagnitude);
+    }
+    if (other instanceof Scalar || other instanceof Percent) {
+      return new this.derivedConstructor(newMagnitude);
+    }
+    const c = Object.assign({}, this.dimension);
+    Dimensions.forEach((u) => c[u] += other.dimension[u]);
+    return new UnverifiedQuantity(newMagnitude, c);
+  }
+  public plus<B extends Quantity<B>>(other: B): T {
+    if (!isEqual(this.dimension, other.dimension)) {
+      throw new Error(`plus failed: expected dimensions to be equal, this=${this}, other=${other}`);
+    }
+    const newMagnitude = this.magnitude.plus(other.magnitude);
+    return new this.derivedConstructor(newMagnitude);
+  }
+}
+
+interface QuantityConstructor<T extends Quantity<T>> {
+  new(magnitude: BigNumber): T;
+}
+
+interface VerifiableQuantity<T extends Quantity<T>> extends QuantityConstructor<T> {
+  sentinel: T;
+  isValidMagnitude?(magnitude: BigNumber): undefined | Error; // TODO doc
+}
+
+class UnverifiedQuantity extends Quantity<UnverifiedQuantity> {
+  constructor(magnitude: BigNumber, dimension: DimensionVector) {
+    class Copy extends UnverifiedQuantity {
+      constructor(magnitude: BigNumber) {
+        super(magnitude, dimension);
+      }
+    }
+    super(Copy, magnitude, dimension);
+  }
+  // TODO consider renaming verify() to is() or shouldBe() or isIn()
+  public verify<T extends Quantity<T>>(vu: VerifiableQuantity<T>): T {
+    if (!isEqual(vu.sentinel.dimension, this.dimension)) {
+      throw new Error(`verify failed: dimensions not equal, expected=${vu}, actual=${this}`);
+    }
+    if (vu.isValidMagnitude !== undefined) {
+      const maybeErr = vu.isValidMagnitude(this.magnitude);
+      if (maybeErr !== undefined) {
+        // TODO wrap maybeErr with dimension context
+        throw maybeErr;
+      }
+    }
+    return new vu(this.magnitude);
+  }
+}
+
+export class Scalar extends Quantity<Scalar> {
+  public static sentinel: Scalar = new Scalar(ZERO);
+  protected static readonly unitDimension: DimensionVector = {
+    tokens: 0,
+    shares: 0,
+  };
+  public scalar: true; // this unique field makes this unit disjoint with other units so that you can't `a: Tokens = new Scalar()`
+  constructor(magnitude: BigNumber) {
+    super(Scalar, magnitude, Scalar.unitDimension);
+  }
+}
+
+export class Percent extends Quantity<Percent> {
+  public static sentinel: Percent = new Percent(ZERO);
+  public static isValidMagnitude(magnitude: BigNumber): undefined | Error {
+    if (magnitude.isLessThan(ZERO) || magnitude.isGreaterThan(ZERO)) {
+      return new Error(`expected Percent to be between 0 and 1.0, actual: ${magnitude}`);
+    }
+    return;
+  }
+  protected static readonly unitDimension: DimensionVector = {
+    tokens: 0,
+    shares: 0,
+  };
+  public percent: true; // this unique field makes this unit disjoint with other units so that you can't `a: Tokens = new Percent2()`
+  constructor(magnitude: BigNumber) {
+    super(Percent, magnitude, Percent.unitDimension);
+  }
+}
+
+class Tokens extends Quantity<Tokens> {
+  public static sentinel: Tokens = new Tokens(ZERO);
+  protected static readonly unitDimension: DimensionVector = {
+    tokens: 1,
+    shares: 0,
+  };
+  public tokens: true; // this unique field makes this unit disjoint with other units so that you can't `a: Tokens = new Scalar()`
+  constructor(magnitude: BigNumber) {
+    super(Tokens, magnitude, Tokens.unitDimension);
+  }
+}
+
+class Shares extends Quantity<Shares> {
+  public static sentinel: Shares = new Shares(ZERO);
+  protected static readonly unitDimension: DimensionVector = {
+    tokens: 0,
+    shares: 1,
+  };
+  public shares: true; // this unique field makes this unit disjoint with other units so that you can't `a: Shares = new Scalar()`
+  constructor(magnitude: BigNumber) {
+    super(Shares, magnitude, Shares.unitDimension);
+  }
+}
+
+// ****************************************************************
+// tests/scratch below here
+
+const t = new Tokens(ZERO);
+const t2 = new Tokens(new BigNumber(3));
+const t3: Tokens = t.plus(t2);
+const s = new Scalar(ZERO);
+const p = new Percent(ZERO);
+
+// TODO these need unit tests too to check for stuff like `v5.tokens == "tokens"`
+const v5: Tokens = t.multipliedBy(s);
+const v6: Tokens = s.multipliedBy(t);
+const v7: UnverifiedQuantity = t.multipliedBy(t);
+const v8: Scalar = s.multipliedBy(s);
+
+const v111: Percent = p.multipliedBy(p);
+const v112: Scalar = s.multipliedBy(p);
+const v113: Scalar = p.multipliedBy(s);
+const v114: Tokens = p.multipliedBy(t);
+const v115: Tokens = t.multipliedBy(p);
+
+const uq2 = new UnverifiedQuantity(ONE, {
+  tokens: 1,
+  shares: 0,
+});
+
+const t8: Tokens = uq2.verify(Tokens);

--- a/src/utils/financial-math.ts
+++ b/src/utils/financial-math.ts
@@ -1,0 +1,14 @@
+import { BigNumber } from "bignumber.js";
+import { Tokens, Shares, Price } from "./dimension-quantity";
+
+const ZERO = new BigNumber(0);
+const ZERO_SHARES = new Shares(ZERO);
+
+// TODO unit test
+// TODO doc
+export function getQuantityClosedFromTrade(prevPosition: Shares, positionDeltaFromTrade: Shares): Shares {
+  if (positionDeltaFromTrade.isZero() || prevPosition.sign === positionDeltaFromTrade.sign) {
+    return ZERO_SHARES;
+  }
+  return prevPosition.abs().min(positionDeltaFromTrade.abs());
+}

--- a/src/utils/financial-math.ts
+++ b/src/utils/financial-math.ts
@@ -1,8 +1,10 @@
 import { Percent, Price, Shares, Tokens } from "./dimension-quantity";
 
-// This library is intended to be a home for all augur financial
-// formulas. The emphasis is on safety and education with mechanisms like more specific
-// types (eg. Shares instead of BigNumber), named parameters/return values (eg. returning a TradeQuantityOpened instead of Shares), and highly structured nouns (eg. passing around a RealizedProfit instead of Tokens).
+// This library is intended to be a home for all augur financial formulas.
+// The emphasis is on safety and education with mechanisms like more specific
+// types (eg. Shares instead of BigNumber), named parameters/return values
+// (eg. returning a TradeQuantityOpened instead of Shares), and highly
+// structured nouns (eg. passing around a RealizedProfit instead of Tokens).
 
 // The documentation is centered around the types, the idea
 // being that financial formuals are mostly self-documenting

--- a/src/utils/financial-math.ts
+++ b/src/utils/financial-math.ts
@@ -1,8 +1,6 @@
 import { Percent, Price, Shares, Tokens } from "./dimension-quantity";
 
-// TODO instead of returning "Tokens", return "RealizedCost" from each function
-
-// TODO doc how these param interfaces act as standard nomenclature/dictionary of nouns for financial math.
+// TODO it's probably unnecessary to document the functions so long as the I/O types are documented
 
 // TODO doc ... ie. current net position, or net position prior to the trade being processed.
 interface NetPosition {
@@ -10,23 +8,18 @@ interface NetPosition {
 }
 
 // TODO doc
-interface AveragePerSharePriceToOpenPosition {
-  averagePerSharePriceToOpenPosition: Price;
-}
-
-// TODO doc... vs. trade quantity, and trade quantity closed
-interface TradePositionDelta {
-  tradePositionDelta: Shares;
-}
-
-// TODO explain how TradePrice works with scalars... this is minus minPrice, right? .... we should have something like f :: MarketListPrice -> MarketMinPrice -> TradePrice to codify this
-interface TradePrice {
-  tradePrice: Price;
+interface NextNetPosition {
+  nextNetPosition: Shares;
 }
 
 // TODO doc
-interface LastPrice {
-  lastPrice: Price | undefined; // TODO explain lastPrice can be undefined because ...
+interface AveragePricePerShareToOpenPosition {
+  averagePricePerShareToOpenPosition: Price;
+}
+
+// TODO doc
+interface NextAveragePricePerShareToOpenPosition {
+  nextAveragePricePerShareToOpenPosition: Price;
 }
 
 // TODO doc
@@ -40,13 +33,33 @@ interface UnrealizedProfit {
 }
 
 // TODO doc
+interface UnrealizedProfitPercent {
+  unrealizedProfitPercent: Percent;
+}
+
+// TODO doc
 interface RealizedCost {
   realizedCost: Tokens;
 }
 
 // TODO doc
+interface NextRealizedCost {
+  nextRealizedCost: Tokens;
+}
+
+// TODO doc
 interface RealizedProfit {
   realizedProfit: Tokens;
+}
+
+// TODO doc
+interface NextRealizedProfit {
+  nextRealizedProfit: Tokens;
+}
+
+// TODO doc
+interface RealizedProfitPercent {
+  realizedProfitPercent: Percent;
 }
 
 // TODO doc
@@ -60,10 +73,61 @@ interface TotalProfit {
 }
 
 // TODO doc
+interface TotalProfitPercent {
+  totalProfitPercent: Percent;
+}
+
+// TODO doc
+interface CurrentValue {
+  currentValue: Tokens;
+}
+
+// TODO doc
 interface FrozenFunds {
   frozenFunds: Tokens;
 }
 
+// TODO doc... vs. trade quantity, and trade quantity closed
+interface TradePositionDelta {
+  tradePositionDelta: Shares;
+}
+
+// TODO doc
+interface TradeQuantityClosed { // TODO rename QuantityClosed?
+  tradeQuantityClosed: Shares;
+}
+
+// TODO doc
+interface TradeQuantityOpened { // TODO rename QuantityOpened?
+  tradeQuantityOpened: Shares;
+}
+
+// TODO explain how TradePrice works with scalars... this is minus minPrice, right? .... we should have something like f :: MarketListPrice -> MarketMinPrice -> TradePrice to codify this
+interface TradePrice {
+  tradePrice: Price;
+}
+
+// TODO doc
+interface TradeRealizedCostDelta {
+  tradeRealizedCostDelta: Tokens;
+}
+
+// TODO doc
+interface TradeRealizedRevenueDelta {
+  tradeRealizedRevenueDelta: Tokens;
+}
+
+// TODO doc
+interface TradeRealizedProfitDelta {
+  tradeRealizedProfitDelta: Tokens;
+}
+
+// TODO doc
+interface LastPrice {
+  lastPrice: Price | undefined; // TODO explain lastPrice can be undefined because ...
+}
+
+// TODO doc
 enum PositionType {
   CLOSED = "closed",
   SHORT = "short",
@@ -80,184 +144,210 @@ export function getPositionType(params: NetPosition): PositionType {
   return PositionType.LONG;
 }
 
-export function tradeGetNextNetPosition(params: NetPosition & TradePositionDelta): Shares {
-  return params.netPosition.plus(params.tradePositionDelta);
+export function getNextNetPosition(params: NetPosition & TradePositionDelta): NextNetPosition {
+  return {
+    nextNetPosition: params.netPosition.plus(params.tradePositionDelta),
+  };
 }
 
-export function tradeGetNextAveragePerSharePriceToOpenPosition(params: NetPosition & AveragePerSharePriceToOpenPosition & TradePositionDelta & TradePrice): Price {
-  const nextNetPosition = tradeGetNextNetPosition(params);
+export function getNextAveragePricePerShareToOpenPosition(params: NetPosition & AveragePricePerShareToOpenPosition & TradePositionDelta & TradePrice): NextAveragePricePerShareToOpenPosition {
+  const { nextNetPosition } = getNextNetPosition(params);
   if (nextNetPosition.isZero()) {
     // TODO doc
-    return Price.ZERO;
+    return { nextAveragePricePerShareToOpenPosition: Price.ZERO };
   } else if (nextNetPosition.sign !== params.netPosition.sign) {
     // TODO doc
-    return params.tradePrice;
+    return { nextAveragePricePerShareToOpenPosition: params.tradePrice };
   }
-  const quantityOpened = tradeGetQuantityOpened(params);
-  if (quantityOpened.isZero()) {
+  const { tradeQuantityOpened } = getTradeQuantityOpened(params);
+  if (tradeQuantityOpened.isZero()) {
     // TODO doc
-    return params.averagePerSharePriceToOpenPosition;
+    return { nextAveragePricePerShareToOpenPosition: params.averagePricePerShareToOpenPosition };
   }
   // TODO doc weighted average
-  return (
-    (params.netPosition.abs().multipliedBy(params.averagePerSharePriceToOpenPosition))
-      .plus(params.tradePositionDelta.abs().multipliedBy(params.tradePrice))
-  ).dividedBy(tradeGetNextNetPosition(params).abs()).expect(Price);
+  return {
+    nextAveragePricePerShareToOpenPosition: (
+      (params.netPosition.abs()
+        .multipliedBy(params.averagePricePerShareToOpenPosition))
+        .plus(params.tradePositionDelta.abs().multipliedBy(params.tradePrice))
+    ).dividedBy(nextNetPosition.abs()).expect(Price),
+  };
 }
 
 // TODO doc ie. netPosition prior to trade ... relationship between TradePositionDelta and TradeQuantityClosed
-export function tradeGetQuantityClosed(params: NetPosition & TradePositionDelta): Shares {
+export function getTradeQuantityClosed(params: NetPosition & TradePositionDelta): TradeQuantityClosed {
   if (params.tradePositionDelta.isZero() ||
     params.tradePositionDelta.sign === params.netPosition.sign) {
-    return Shares.ZERO;
+    return { tradeQuantityClosed: Shares.ZERO };
   }
-  return params.netPosition.abs().min(params.tradePositionDelta.abs());
+  return { tradeQuantityClosed: params.netPosition.abs().min(params.tradePositionDelta.abs()) };
 }
 
 // TODO doc ie. netPosition prior to trade ... relationship between TradePositionDelta and TradeQuantityOpened
-export function tradeGetQuantityOpened(params: NetPosition & TradePositionDelta): Shares {
-  // TODO simpler algorithm?
+export function getTradeQuantityOpened(params: NetPosition & TradePositionDelta): TradeQuantityOpened {
   if (params.tradePositionDelta.isZero()) {
-    return Shares.ZERO;
+    return { tradeQuantityOpened: Shares.ZERO };
+  } else if (params.tradePositionDelta.sign === params.netPosition.sign) {
+    return { tradeQuantityOpened: params.tradePositionDelta.abs() }; // position opened further
+  } else if (params.tradePositionDelta.abs().gt(params.netPosition.abs())) {
+    return { tradeQuantityOpened: params.tradePositionDelta.plus(params.netPosition).abs() }; // position reversed
   }
-  if (params.tradePositionDelta.sign === params.netPosition.sign) {
-    // position opened further
-    return params.tradePositionDelta.abs();
-  }
-  if (params.tradePositionDelta.abs().gt(params.netPosition.abs())) {
-    // position reversed
-    return params.tradePositionDelta.plus(params.netPosition).abs();
-  }
-  // position partially or fully closed
-  return Shares.ZERO;
+  return { tradeQuantityOpened: Shares.ZERO }; // position partially or fully closed
 }
 
 // TODO doc ie. netPosition prior to trade
-export function tradeGetRealizedCostDelta(params: NetPosition & AveragePerSharePriceToOpenPosition & TradePositionDelta & TradePrice): Tokens {
+export function getTradeRealizedCostDelta(params: NetPosition & AveragePricePerShareToOpenPosition & TradePositionDelta & TradePrice): TradeRealizedCostDelta {
   const positionType = getPositionType(params);
   if (positionType === PositionType.CLOSED) {
-    return Tokens.ZERO;
+    return { tradeRealizedCostDelta: Tokens.ZERO };
   }
-  const tradeQuantityClosed = tradeGetQuantityClosed(params);
+  const { tradeQuantityClosed } = getTradeQuantityClosed(params);
   if (positionType === PositionType.SHORT) {
     // TODO doc
-    return params.tradePrice.multipliedBy(tradeQuantityClosed).expect(Tokens);
+    return { tradeRealizedCostDelta: params.tradePrice.multipliedBy(tradeQuantityClosed).expect(Tokens) };
   }
   // positionType is long
   // TODO doc
-  return params.averagePerSharePriceToOpenPosition
-    .multipliedBy(tradeQuantityClosed).expect(Tokens);
+  return {
+    tradeRealizedCostDelta: params.averagePricePerShareToOpenPosition
+      .multipliedBy(tradeQuantityClosed).expect(Tokens),
+  };
 }
 
-export function tradeGetNextRealizedCost(params: RealizedCost & NetPosition & AveragePerSharePriceToOpenPosition & TradePositionDelta & TradePrice): Tokens {
-  return params.realizedCost.plus(tradeGetRealizedCostDelta(params));
+export function getNextRealizedCost(params: RealizedCost & NetPosition & AveragePricePerShareToOpenPosition & TradePositionDelta & TradePrice): NextRealizedCost {
+  return {
+    nextRealizedCost: params.realizedCost
+      .plus(getTradeRealizedCostDelta(params).tradeRealizedCostDelta),
+  };
 }
 
 // TODO doc ie. netPosition prior to trade
-export function tradeGetRealizedRevenueDelta(params: NetPosition & AveragePerSharePriceToOpenPosition & TradePositionDelta & TradePrice): Tokens {
+export function getTradeRealizedRevenueDelta(params: NetPosition & AveragePricePerShareToOpenPosition & TradePositionDelta & TradePrice): TradeRealizedRevenueDelta {
   const positionType = getPositionType(params);
   if (positionType === PositionType.CLOSED) {
-    return Tokens.ZERO;
+    return { tradeRealizedRevenueDelta: Tokens.ZERO };
   }
-  const tradeQuantityClosed = tradeGetQuantityClosed(params);
+  const { tradeQuantityClosed } = getTradeQuantityClosed(params);
   if (positionType === PositionType.SHORT) {
     // TODO doc
-    return params.averagePerSharePriceToOpenPosition
-      .multipliedBy(tradeQuantityClosed).expect(Tokens);
+    return {
+      tradeRealizedRevenueDelta: params.averagePricePerShareToOpenPosition
+        .multipliedBy(tradeQuantityClosed).expect(Tokens),
+    };
   }
   // positionType is long
   // TODO doc
-  return params.tradePrice.multipliedBy(tradeQuantityClosed).expect(Tokens);
+  return { tradeRealizedRevenueDelta: params.tradePrice.multipliedBy(tradeQuantityClosed).expect(Tokens) };
 }
 
-export function tradeGetRealizedProfitDelta(params: NetPosition & AveragePerSharePriceToOpenPosition & TradePositionDelta & TradePrice): Tokens {
-  return tradeGetRealizedRevenueDelta(params).minus(tradeGetRealizedCostDelta(params));
+export function getTradeRealizedProfitDelta(params: NetPosition & AveragePricePerShareToOpenPosition & TradePositionDelta & TradePrice): TradeRealizedProfitDelta {
+  return {
+    tradeRealizedProfitDelta: getTradeRealizedRevenueDelta(params).tradeRealizedRevenueDelta
+      .minus(getTradeRealizedCostDelta(params).tradeRealizedCostDelta),
+  };
 }
 
-export function tradeGetNextRealizedProfit(params: RealizedProfit & NetPosition & AveragePerSharePriceToOpenPosition & TradePositionDelta & TradePrice): Tokens {
-  return params.realizedProfit.plus(tradeGetRealizedProfitDelta(params));
+export function getNextRealizedProfit(params: RealizedProfit & NetPosition & AveragePricePerShareToOpenPosition & TradePositionDelta & TradePrice): NextRealizedProfit {
+  return {
+    nextRealizedProfit: params.realizedProfit
+      .plus(getTradeRealizedProfitDelta(params).tradeRealizedProfitDelta),
+  };
 }
 
 // TODO doc ie. netPosition prior to trade
-export function positionGetUnrealizedCost(params: NetPosition & AveragePerSharePriceToOpenPosition & LastPrice): Tokens {
+export function getUnrealizedCost(params: NetPosition & AveragePricePerShareToOpenPosition & LastPrice): UnrealizedCost {
   switch (getPositionType(params)) {
     case PositionType.CLOSED:
-      return Tokens.ZERO;
+      return { unrealizedCost: Tokens.ZERO };
     case PositionType.SHORT:
       // TODO doc
       if (params.lastPrice === undefined) {
-        return Tokens.ZERO;
+        return { unrealizedCost: Tokens.ZERO };
       }
-      return params.netPosition.abs().multipliedBy(params.lastPrice).expect(Tokens);
+      return { unrealizedCost: params.netPosition.abs().multipliedBy(params.lastPrice).expect(Tokens) };
     case PositionType.LONG:
       // TODO doc
-      return params.netPosition.abs()
-        .multipliedBy(params.averagePerSharePriceToOpenPosition).expect(Tokens);
+      return {
+        unrealizedCost: params.netPosition.abs()
+          .multipliedBy(params.averagePricePerShareToOpenPosition).expect(Tokens),
+      };
   }
 }
 
 // TODO doc
-export function positionGetTotalCost(params: NetPosition & AveragePerSharePriceToOpenPosition & LastPrice & RealizedCost): Tokens {
-  return positionGetUnrealizedCost(params).plus(params.realizedCost);
+export function getTotalCost(params: NetPosition & AveragePricePerShareToOpenPosition & LastPrice & RealizedCost): TotalCost {
+  return { totalCost: getUnrealizedCost(params).unrealizedCost.plus(params.realizedCost) };
 }
 
 // TODO doc
 // TODO allow currentSharePrice to be undefined and return zero
-export function positionGetUnrealizedProfit(params: NetPosition & AveragePerSharePriceToOpenPosition & LastPrice): Tokens {
+export function getUnrealizedProfit(params: NetPosition & AveragePricePerShareToOpenPosition & LastPrice): UnrealizedProfit {
   if (params.lastPrice === undefined) {
-    return Tokens.ZERO;
+    return { unrealizedProfit: Tokens.ZERO };
   }
   // TODO explain how this work for both long/short because -1 * -1 cancels out
-  return params.netPosition.multipliedBy(
-    params.lastPrice.minus(params.averagePerSharePriceToOpenPosition)).abs().expect(Tokens); // abs() prevents unrealized profit from appearing as "-0" on JSON.stringify()
+  return {
+    unrealizedProfit: params.netPosition.multipliedBy(
+      params.lastPrice.minus(params.averagePricePerShareToOpenPosition)).abs().expect(Tokens), // abs() prevents unrealized profit from appearing as "-0" on JSON.stringify()
+  };
 }
 
-export function positionGetTotalProfit(params: NetPosition & AveragePerSharePriceToOpenPosition & LastPrice & RealizedProfit): Tokens {
-  return positionGetUnrealizedProfit(params).plus(params.realizedProfit);
+export function getTotalProfit(params: NetPosition & AveragePricePerShareToOpenPosition & LastPrice & RealizedProfit): TotalProfit {
+  return {
+    totalProfit: getUnrealizedProfit(params).unrealizedProfit
+      .plus(params.realizedProfit),
+  };
 }
 
 // TODO doc
-export function positionGetCurrentValue(params: NetPosition & AveragePerSharePriceToOpenPosition & LastPrice & FrozenFunds): Tokens {
-  return positionGetUnrealizedProfit(params).minus(params.frozenFunds);
+export function getCurrentValue(params: NetPosition & AveragePricePerShareToOpenPosition & LastPrice & FrozenFunds): CurrentValue {
+  return {
+    currentValue: getUnrealizedProfit(params).unrealizedProfit
+      .minus(params.frozenFunds),
+  };
 }
 
 // TODO doc, returns scale of 0..1
-export function positionGetRealizedProfitPercent(params: RealizedCost & RealizedProfit): Percent {
+export function getRealizedProfitPercent(params: RealizedCost & RealizedProfit): RealizedProfitPercent {
   if (params.realizedCost.isZero()) {
     // user spent nothing and so can't have a percent profit on
     // nothing; we might consider realizedProfitPercent to be
     // undefined, but instead we return zero for convenience.
-    return Percent.ZERO;
+    return { realizedProfitPercent: Percent.ZERO };
   }
-  return params.realizedProfit.dividedBy(params.realizedCost).expect(Percent);
+  return {
+    realizedProfitPercent: params.realizedProfit.dividedBy(params.realizedCost).expect(Percent),
+  };
 }
 
 // TODO doc, returns scale of 0..1 ... clients should default to providing netposition/etc. instead of passing unrealizedCost/unraelizedProfit, to minimize derived state in the client's local scope and maximize computations done safely in this library. But, some clients don't have access to LastPrice/etc. and that's why we support passing unrealizedCost/unrealizedProfit.
-export function positionGetUnrealizedProfitPercent(params:
-  (NetPosition & AveragePerSharePriceToOpenPosition & LastPrice)
-  | (UnrealizedCost & UnrealizedProfit)): Percent {
-  const unrealizedCost = "unrealizedCost" in params ? params.unrealizedCost : positionGetUnrealizedCost(params);
+export function getUnrealizedProfitPercent(params:
+  (NetPosition & AveragePricePerShareToOpenPosition & LastPrice)
+  | (UnrealizedCost & UnrealizedProfit)): UnrealizedProfitPercent {
+  const { unrealizedCost } = "unrealizedCost" in params ? params : getUnrealizedCost(params);
   if (unrealizedCost.isZero()) {
     // user spent nothing and so can't have a percent profit on
     // nothing; we might consider unrealizedProfitPercent to be
     // undefined, but instead we return zero for convenience.
-    return Percent.ZERO;
+    return { unrealizedProfitPercent: Percent.ZERO };
   }
-  const unrealizedProfit = "unrealizedProfit" in params ? params.unrealizedProfit : positionGetUnrealizedProfit(params);
-  return unrealizedProfit.dividedBy(unrealizedCost).expect(Percent);
+  const { unrealizedProfit } = "unrealizedProfit" in params ? params : getUnrealizedProfit(params);
+  return {
+    unrealizedProfitPercent: unrealizedProfit.dividedBy(unrealizedCost).expect(Percent),
+  };
 }
 
 // TODO doc, returns scale of 0..1
-export function positionGetTotalProfitPercent(params:
-  (NetPosition & AveragePerSharePriceToOpenPosition & LastPrice & RealizedCost & RealizedProfit)
-  | (TotalCost & TotalProfit)): Percent {
-  const totalCost = "totalCost" in params ? params.totalCost : positionGetTotalCost(params);
+export function getTotalProfitPercent(params:
+  (NetPosition & AveragePricePerShareToOpenPosition & LastPrice & RealizedCost & RealizedProfit)
+  | (TotalCost & TotalProfit)): TotalProfitPercent {
+  const { totalCost } = "totalCost" in params ? params : getTotalCost(params);
   if (totalCost.isZero()) {
     // user spent nothing and so can't have a percent profit on
     // nothing; we might consider totalProfitPercent to be
     // undefined, but instead we return zero for convenience.
-    return Percent.ZERO;
+    return { totalProfitPercent: Percent.ZERO };
   }
-  const totalProfit = "totalProfit" in params ? params.totalProfit : positionGetTotalProfit(params);
-  return totalProfit.dividedBy(totalCost).expect(Percent);
+  const { totalProfit } = "totalProfit" in params ? params : getTotalProfit(params);
+  return { totalProfitPercent: totalProfit.dividedBy(totalCost).expect(Percent) };
 }

--- a/src/utils/financial-math.ts
+++ b/src/utils/financial-math.ts
@@ -88,7 +88,7 @@ export function tradeGetNextAveragePerSharePriceToOpenPosition(params: NetPositi
   const nextNetPosition = tradeGetNextNetPosition(params);
   if (nextNetPosition.isZero()) {
     // TODO doc
-    return Price.sentinel;
+    return Price.ZERO;
   } else if (nextNetPosition.sign !== params.netPosition.sign) {
     // TODO doc
     return params.tradePrice;
@@ -109,7 +109,7 @@ export function tradeGetNextAveragePerSharePriceToOpenPosition(params: NetPositi
 export function tradeGetQuantityClosed(params: NetPosition & TradePositionDelta): Shares {
   if (params.tradePositionDelta.isZero() ||
     params.tradePositionDelta.sign === params.netPosition.sign) {
-    return Shares.sentinel;
+    return Shares.ZERO;
   }
   return params.netPosition.abs().min(params.tradePositionDelta.abs());
 }
@@ -118,7 +118,7 @@ export function tradeGetQuantityClosed(params: NetPosition & TradePositionDelta)
 export function tradeGetQuantityOpened(params: NetPosition & TradePositionDelta): Shares {
   // TODO simpler algorithm?
   if (params.tradePositionDelta.isZero()) {
-    return Shares.sentinel;
+    return Shares.ZERO;
   }
   if (params.tradePositionDelta.sign === params.netPosition.sign) {
     // position opened further
@@ -129,14 +129,14 @@ export function tradeGetQuantityOpened(params: NetPosition & TradePositionDelta)
     return params.tradePositionDelta.plus(params.netPosition).abs();
   }
   // position partially or fully closed
-  return Shares.sentinel;
+  return Shares.ZERO;
 }
 
 // TODO doc ie. netPosition prior to trade
 export function tradeGetRealizedCostDelta(params: NetPosition & AveragePerSharePriceToOpenPosition & TradePositionDelta & TradePrice): Tokens {
   const positionType = getPositionType(params);
   if (positionType === PositionType.CLOSED) {
-    return Tokens.sentinel;
+    return Tokens.ZERO;
   }
   const tradeQuantityClosed = tradeGetQuantityClosed(params);
   if (positionType === PositionType.SHORT) {
@@ -157,7 +157,7 @@ export function tradeGetNextRealizedCost(params: RealizedCost & NetPosition & Av
 export function tradeGetRealizedRevenueDelta(params: NetPosition & AveragePerSharePriceToOpenPosition & TradePositionDelta & TradePrice): Tokens {
   const positionType = getPositionType(params);
   if (positionType === PositionType.CLOSED) {
-    return Tokens.sentinel;
+    return Tokens.ZERO;
   }
   const tradeQuantityClosed = tradeGetQuantityClosed(params);
   if (positionType === PositionType.SHORT) {
@@ -182,11 +182,11 @@ export function tradeGetNextRealizedProfit(params: RealizedProfit & NetPosition 
 export function positionGetUnrealizedCost(params: NetPosition & AveragePerSharePriceToOpenPosition & LastPrice): Tokens {
   switch (getPositionType(params)) {
     case PositionType.CLOSED:
-      return Tokens.sentinel;
+      return Tokens.ZERO;
     case PositionType.SHORT:
       // TODO doc
       if (params.lastPrice === undefined) {
-        return Tokens.sentinel;
+        return Tokens.ZERO;
       }
       return params.netPosition.abs().multipliedBy(params.lastPrice).expect(Tokens);
     case PositionType.LONG:
@@ -205,7 +205,7 @@ export function positionGetTotalCost(params: NetPosition & AveragePerSharePriceT
 // TODO allow currentSharePrice to be undefined and return zero
 export function positionGetUnrealizedProfit(params: NetPosition & AveragePerSharePriceToOpenPosition & LastPrice): Tokens {
   if (params.lastPrice === undefined) {
-    return Tokens.sentinel;
+    return Tokens.ZERO;
   }
   // TODO explain how this work for both long/short because -1 * -1 cancels out
   return params.netPosition.multipliedBy(
@@ -227,7 +227,7 @@ export function positionGetRealizedProfitPercent(params: RealizedCost & Realized
     // user spent nothing and so can't have a percent profit on
     // nothing; we might consider realizedProfitPercent to be
     // undefined, but instead we return zero for convenience.
-    return Percent.sentinel;
+    return Percent.ZERO;
   }
   return params.realizedProfit.dividedBy(params.realizedCost).expect(Percent);
 }
@@ -241,7 +241,7 @@ export function positionGetUnrealizedProfitPercent(params:
     // user spent nothing and so can't have a percent profit on
     // nothing; we might consider unrealizedProfitPercent to be
     // undefined, but instead we return zero for convenience.
-    return Percent.sentinel;
+    return Percent.ZERO;
   }
   const unrealizedProfit = "unrealizedProfit" in params ? params.unrealizedProfit : positionGetUnrealizedProfit(params);
   return unrealizedProfit.dividedBy(unrealizedCost).expect(Percent);
@@ -256,7 +256,7 @@ export function positionGetTotalProfitPercent(params:
     // user spent nothing and so can't have a percent profit on
     // nothing; we might consider totalProfitPercent to be
     // undefined, but instead we return zero for convenience.
-    return Percent.sentinel;
+    return Percent.ZERO;
   }
   const totalProfit = "totalProfit" in params ? params.totalProfit : positionGetTotalProfit(params);
   return totalProfit.dividedBy(totalCost).expect(Percent);

--- a/src/utils/financial-math.ts
+++ b/src/utils/financial-math.ts
@@ -1,14 +1,140 @@
 import { BigNumber } from "bignumber.js";
-import { Tokens, Shares, Price } from "./dimension-quantity";
+import { Percent, Price, Scalar, Shares, Tokens } from "./dimension-quantity";
 
 const ZERO = new BigNumber(0);
 const ZERO_SHARES = new Shares(ZERO);
 
 // TODO unit test
 // TODO doc
-export function getQuantityClosedFromTrade(prevPosition: Shares, positionDeltaFromTrade: Shares): Shares {
+export function tradeGetQuantityClosed(prevPosition: Shares, positionDeltaFromTrade: Shares): Shares {
   if (positionDeltaFromTrade.isZero() || prevPosition.sign === positionDeltaFromTrade.sign) {
     return ZERO_SHARES;
   }
   return prevPosition.abs().min(positionDeltaFromTrade.abs());
+}
+
+// TODO doc ... averagePrice is what... as of when.... netPosition is interpreted how...
+export function positionGetUnrealizedCost(netPosition: Shares, averagePerSharePriceToOpenPosition: Price): Tokens {
+  return netPosition.abs().multipliedBy(averagePerSharePriceToOpenPosition).expect(Tokens);
+}
+
+// TODO doc eg. currentSharePrice might be lastPrice
+export function positionGetProfitPerShare(
+  netPosition: Shares,
+  averagePerSharePriceToOpenPosition: Price,
+  currentSharePrice: Price): Price {
+  if (netPosition.lt(Shares.sentinel)) {
+    // netPosition is short, so user profits as currentSharePrice decreases
+    return averagePerSharePriceToOpenPosition.minus(currentSharePrice);
+  }
+  // netPosition is long, so user profits as currentSharePrice increases
+  return currentSharePrice.minus(averagePerSharePriceToOpenPosition);
+}
+
+// TODO doc
+// TODO allow currentSharePrice to be undefined and return zero
+export function positionGetUnrealizedProfit(
+  netPosition: Shares,
+  averagePerSharePriceToOpenPosition: Price,
+  currentSharePrice: Price | undefined): Tokens {
+  if (currentSharePrice === undefined) {
+    return Tokens.sentinel;
+  }
+  return positionGetProfitPerShare(netPosition, averagePerSharePriceToOpenPosition, currentSharePrice).multipliedBy(netPosition.abs()).expect(Tokens);
+}
+
+export function positionGetTotalProfit(
+  netPosition: Shares,
+  averagePerSharePriceToOpenPosition: Price,
+  currentSharePrice: Price | undefined,
+  realizedProfit: Tokens): Tokens {
+  return positionGetUnrealizedProfit(netPosition, averagePerSharePriceToOpenPosition, currentSharePrice).plus(realizedProfit);
+}
+
+// TODO doc
+export function positionGetCurrentValue(
+  netPosition: Shares,
+  averagePerSharePriceToOpenPosition: Price,
+  currentSharePrice: Price | undefined,
+  frozenFunds: Tokens): Tokens {
+  return positionGetUnrealizedProfit(netPosition, averagePerSharePriceToOpenPosition, currentSharePrice).minus(frozenFunds);
+}
+
+// TODO doc, returns scale of 0..1
+export function positionGetRealizedProfitPercent(realizedCost: Tokens, realizedProfit: Tokens): Percent {
+  if (realizedCost.isZero()) {
+    // user spent nothing and so can't have a percent profit on
+    // nothing; we might consider realizedProfitPercent to be
+    // undefined, but instead we return zero for convenience.
+    return Percent.sentinel;
+  }
+  return ((realizedCost.plus(realizedProfit))
+    .dividedBy(realizedCost)).expect(Percent)
+    .minus(Scalar.ONE);
+}
+
+// TODO doc, returns scale of 0..1
+export function positionGetUnrealizedProfitPercent(
+  netPosition: Shares,
+  averagePerSharePriceToOpenPosition: Price,
+  currentSharePrice: Price | undefined): Percent {
+  // unrealizedProfitPercent is same formula as realizedProfitPercent
+  return positionGetRealizedProfitPercent(
+    positionGetUnrealizedCost(netPosition, averagePerSharePriceToOpenPosition),
+    positionGetUnrealizedProfit(netPosition, averagePerSharePriceToOpenPosition, currentSharePrice));
+}
+
+// positionGetUnrealizedProfitPercent2() is for some clients
+// who have unrealizedCost/unrealizedProfit, but lost the
+// context to compute these from currentSharePrice/etc. Clients
+// should default to positionGetUnrealizedProfitPercent() to
+// avoid unnecessary derived state in the client's local scope.
+export function positionGetUnrealizedProfitPercent2(unrealizedCost: Tokens, unrealizedProfit: Tokens): Percent {
+  // unrealizedProfitPercent is same formula as realizedProfitPercent
+  return positionGetRealizedProfitPercent(unrealizedCost, unrealizedProfit);
+}
+
+// TODO doc, returns scale of 0..1
+export function positionGetTotalProfitPercent(
+  netPosition: Shares,
+  averagePerSharePriceToOpenPosition: Price,
+  currentSharePrice: Price | undefined,
+  realizedCost: Tokens,
+  realizedProfit: Tokens): Percent {
+  const unrealizedCost = positionGetUnrealizedCost(netPosition, averagePerSharePriceToOpenPosition);
+  const totalCost = unrealizedCost.plus(realizedCost);
+  if (totalCost.isZero()) {
+    // user spent nothing and so can't have a percent profit on
+    // nothing; we might consider realizedProfitPercent to be
+    // undefined, but instead we return zero for convenience.
+    return Percent.sentinel;
+  }
+  const unrealizedProfit = positionGetUnrealizedProfit(netPosition, averagePerSharePriceToOpenPosition, currentSharePrice);
+
+  return ((totalCost.plus(unrealizedProfit).plus(realizedProfit))
+    .dividedBy(totalCost)).expect(Percent)
+    .minus(Scalar.ONE);
+}
+
+// positionGetTotalProfitPercent2() is for some clients
+// who have unrealizedCost/unrealizedProfit, but lost the
+// context to compute these from currentSharePrice/etc. Clients
+// should default to positionGetTotalProfitPercent() to
+// avoid unnecessary derived state in the client's local scope.
+export function positionGetTotalProfitPercent2(
+  // TODO consider making this object params.... four variables all of same type easy to mistype
+  unrealizedCost: Tokens,
+  unrealizedProfit: Tokens,
+  realizedCost: Tokens,
+  realizedProfit: Tokens): Percent {
+  const totalCost = unrealizedCost.plus(realizedCost);
+  if (totalCost.isZero()) {
+    // user spent nothing and so can't have a percent profit on
+    // nothing; we might consider realizedProfitPercent to be
+    // undefined, but instead we return zero for convenience.
+    return Percent.sentinel;
+  }
+  return ((totalCost.plus(unrealizedProfit).plus(realizedProfit))
+    .dividedBy(totalCost)).expect(Percent)
+    .minus(Scalar.ONE);
 }

--- a/src/utils/financial-math.ts
+++ b/src/utils/financial-math.ts
@@ -1,8 +1,18 @@
 import { Percent, Price, Shares, Tokens } from "./dimension-quantity";
 
-// TODO it's probably unnecessary to document the functions so long as the I/O types are documented
+// This library is intended to be a home for all augur financial
+// formulas. The emphasis is on safety and education with mechanisms like more specific
+// types (eg. Shares instead of BigNumber), named parameters/return values (eg. returning a TradeQuantityOpened instead of Shares), and highly structured nouns (eg. passing around a RealizedProfit instead of Tokens).
 
-// TODO doc ... ie. current net position, or net position prior to the trade being processed.
+// The documentation is centered around the types, the idea
+// being that financial formuals are mostly self-documenting
+// if you can understand the input and output types.
+
+// NetPosition is the number of shares a user currently owns in a market
+// outcome. If NetPosition is positive (negative), the user has a "long"
+// ("short") position and earns money if the price goes up (down). If NetPosition
+// is zero the position is said to be "closed". In the context of a trade,
+// NetPosition is prior to the trade being processed, see NextNetPosition.
 interface NetPosition {
   netPosition: Shares;
 }
@@ -93,16 +103,16 @@ interface TradePositionDelta {
 }
 
 // TODO doc
-interface TradeQuantityClosed { // TODO rename QuantityClosed?
+interface TradeQuantityClosed {
   tradeQuantityClosed: Shares;
 }
 
 // TODO doc
-interface TradeQuantityOpened { // TODO rename QuantityOpened?
+interface TradeQuantityOpened {
   tradeQuantityOpened: Shares;
 }
 
-// TODO explain how TradePrice works with scalars... this is minus minPrice, right? .... we should have something like f :: MarketListPrice -> MarketMinPrice -> TradePrice to codify this
+// TODO explain how TradePrice works with scalars... this is minus minPrice, right? .... we should have something like f :: MarketListPrice -> MarketMinPrice -> TradeDisplayPrice to codify this (UPDATE -- yes do this and then update this formula being used inline in get-profit-loss and update-profit-loss)
 interface TradePrice {
   tradePrice: Price;
 }
@@ -280,7 +290,6 @@ export function getTotalCost(params: NetPosition & AveragePricePerShareToOpenPos
 }
 
 // TODO doc
-// TODO allow currentSharePrice to be undefined and return zero
 export function getUnrealizedProfit(params: NetPosition & AveragePricePerShareToOpenPosition & LastPrice): UnrealizedProfit {
   if (params.lastPrice === undefined) {
     return { unrealizedProfit: Tokens.ZERO };
@@ -299,7 +308,6 @@ export function getTotalProfit(params: NetPosition & AveragePricePerShareToOpenP
   };
 }
 
-// TODO doc
 export function getCurrentValue(params: NetPosition & AveragePricePerShareToOpenPosition & LastPrice & FrozenFunds): CurrentValue {
   return {
     currentValue: getUnrealizedProfit(params).unrealizedProfit
@@ -307,7 +315,6 @@ export function getCurrentValue(params: NetPosition & AveragePricePerShareToOpen
   };
 }
 
-// TODO doc, returns scale of 0..1
 export function getRealizedProfitPercent(params: RealizedCost & RealizedProfit): RealizedProfitPercent {
   if (params.realizedCost.isZero()) {
     // user spent nothing and so can't have a percent profit on
@@ -337,7 +344,7 @@ export function getUnrealizedProfitPercent(params:
   };
 }
 
-// TODO doc, returns scale of 0..1
+// TODO explain multiple param sets
 export function getTotalProfitPercent(params:
   (NetPosition & AveragePricePerShareToOpenPosition & LastPrice & RealizedCost & RealizedProfit)
   | (TotalCost & TotalProfit)): TotalProfitPercent {

--- a/test/unit/server/getters/get-user-trading-positions.js
+++ b/test/unit/server/getters/get-user-trading-positions.js
@@ -75,13 +75,13 @@ describe("server/getters/get-user-trading-positions#Binary-1", () => {
       offset: null,
     });
 
-    expect(tradingPositions[0].netPosition.toString()).toEqual("-7");
-    expect(tradingPositions[0].averagePrice.toString()).toEqual("0.65");
-    expect(tradingPositions[0].unrealized.toString()).toEqual("0.49");
-    expect(tradingPositions[0].realized.toString()).toEqual("0.21");
-    expect(tradingPositions[0].frozenFunds.toString()).toEqual("2.45");
+    expect(tradingPositions[0].netPosition).toEqual("-7");
+    expect(tradingPositions[0].averagePrice).toEqual("0.65");
+    expect(tradingPositions[0].unrealized).toEqual("0.49");
+    expect(tradingPositions[0].realized).toEqual("0.21");
+    expect(tradingPositions[0].frozenFunds).toEqual("2.45");
 
-    expect(frozenFundsTotal.frozenFunds.toString()).toEqual(bn(2.45).plus(validityBondSumInEth).toString());
+    expect(frozenFundsTotal.frozenFunds).toEqual(bn(2.45).plus(validityBondSumInEth).toString());
   });
 });
 
@@ -170,13 +170,13 @@ describe("server/getters/get-user-trading-positions#Binary-2", () => {
       offset: null,
     });
 
-    expect(tradingPositions[0].averagePrice.toString()).toEqual("0.6305");
-    expect(tradingPositions[0].netPosition.toString()).toEqual("-3");
-    expect(tradingPositions[0].realized.toString()).toEqual("4.8785");
-    expect(tradingPositions[0].unrealized.toString()).toEqual("1.4415");
-    expect(tradingPositions[0].frozenFunds.toString()).toEqual("1.1085");
+    expect(tradingPositions[0].averagePrice).toEqual("0.6305");
+    expect(tradingPositions[0].netPosition).toEqual("-3");
+    expect(tradingPositions[0].realized).toEqual("4.8785");
+    expect(tradingPositions[0].unrealized).toEqual("1.4415");
+    expect(tradingPositions[0].frozenFunds).toEqual("1.1085");
 
-    expect(frozenFundsTotal.frozenFunds.toString()).toEqual(bn(1.1085).plus(validityBondSumInEth).toString());
+    expect(frozenFundsTotal.frozenFunds).toEqual(bn(1.1085).plus(validityBondSumInEth).toString());
   });
 
   it("get the positions for an account which has no trades", async () => {
@@ -281,23 +281,23 @@ describe("server/getters/get-user-trading-positions#Cat3-1", () => {
     const positionB = tradingPositions[1];
     const positionC = tradingPositions[2];
 
-    expect(positionA.netPosition.toString()).toEqual("0");
-    expect(positionA.averagePrice.toString()).toEqual("0");
-    expect(positionA.unrealized.toString()).toEqual("0");
-    expect(positionA.realized.toString()).toEqual("0.3");
-    expect(positionA.frozenFunds.toString()).toEqual("0");
+    expect(positionA.netPosition).toEqual("0");
+    expect(positionA.averagePrice).toEqual("0");
+    expect(positionA.unrealized).toEqual("0");
+    expect(positionA.realized).toEqual("0.3");
+    expect(positionA.frozenFunds).toEqual("0");
 
-    expect(positionB.netPosition.toString()).toEqual("-2");
-    expect(positionB.averagePrice.toString()).toEqual("0.2");
-    expect(positionB.unrealized.toString()).toEqual("0");
-    expect(positionB.realized.toString()).toEqual("0");
-    expect(positionB.frozenFunds.toString()).toEqual("1.6");
+    expect(positionB.netPosition).toEqual("-2");
+    expect(positionB.averagePrice).toEqual("0.2");
+    expect(positionB.unrealized).toEqual("0");
+    expect(positionB.realized).toEqual("0");
+    expect(positionB.frozenFunds).toEqual("1.6");
 
-    expect(positionC.netPosition.toString()).toEqual("0.5");
-    expect(positionC.averagePrice.toString()).toEqual("0.3");
-    expect(positionC.unrealized.toString()).toEqual("0");
-    expect(positionC.realized.toString()).toEqual("0");
-    expect(positionC.frozenFunds.toString()).toEqual("0.15");
+    expect(positionC.netPosition).toEqual("0.5");
+    expect(positionC.averagePrice).toEqual("0.3");
+    expect(positionC.unrealized).toEqual("0");
+    expect(positionC.realized).toEqual("0");
+    expect(positionC.frozenFunds).toEqual("0.15");
 
     expect(frozenFundsTotal.frozenFunds.toString()).toEqual(bn(1.75).plus(validityBondSumInEth).toString());
   });
@@ -385,25 +385,25 @@ describe("server/getters/get-user-trading-positions#Cat3-2", () => {
     const positionB = tradingPositions[1];
     const positionC = tradingPositions[2];
 
-    expect(positionA.netPosition.toString()).toEqual("-5");
-    expect(positionA.averagePrice.toString()).toEqual("0.4");
-    expect(positionA.unrealized.toString()).toEqual("0");
-    expect(positionA.realized.toString()).toEqual("0");
-    expect(positionA.frozenFunds.toString()).toEqual("3");
+    expect(positionA.netPosition).toEqual("-5");
+    expect(positionA.averagePrice).toEqual("0.4");
+    expect(positionA.unrealized).toEqual("0");
+    expect(positionA.realized).toEqual("0");
+    expect(positionA.frozenFunds).toEqual("3");
 
-    expect(positionB.netPosition.toString()).toEqual("-3");
-    expect(positionB.averagePrice.toString()).toEqual("0.35");
-    expect(positionB.unrealized.toString()).toEqual("0");
-    expect(positionB.realized.toString()).toEqual("0");
-    expect(positionB.frozenFunds.toString()).toEqual("-1.05");
+    expect(positionB.netPosition).toEqual("-3");
+    expect(positionB.averagePrice).toEqual("0.35");
+    expect(positionB.unrealized).toEqual("0");
+    expect(positionB.realized).toEqual("0");
+    expect(positionB.frozenFunds).toEqual("-1.05");
 
-    expect(positionC.netPosition.toString()).toEqual("-2");
-    expect(positionC.averagePrice.toString()).toEqual("0.3");
-    expect(positionC.unrealized.toString()).toEqual("0.4");
-    expect(positionC.realized.toString()).toEqual("1.6");
-    expect(positionC.frozenFunds.toString()).toEqual("-0.6");
+    expect(positionC.netPosition).toEqual("-2");
+    expect(positionC.averagePrice).toEqual("0.3");
+    expect(positionC.unrealized).toEqual("0.4");
+    expect(positionC.realized).toEqual("1.6");
+    expect(positionC.frozenFunds).toEqual("-0.6");
 
-    expect(frozenFundsTotal.frozenFunds.toString()).toEqual(bn(1.35).plus(validityBondSumInEth).toString());
+    expect(frozenFundsTotal.frozenFunds).toEqual(bn(1.35).plus(validityBondSumInEth).toString());
   });
 });
 
@@ -507,25 +507,25 @@ describe("server/getters/get-user-trading-positions#Cat3-3", () => {
     const positionB = tradingPositions[1];
     const positionC = tradingPositions[2];
 
-    expect(positionA.netPosition.toString()).toEqual("0");
-    expect(positionA.averagePrice.toString()).toEqual("0");
-    expect(positionA.unrealized.toString()).toEqual("0");
-    expect(positionA.realized.toString()).toEqual("-0.5");
-    expect(positionA.frozenFunds.toString()).toEqual("2");
+    expect(positionA.netPosition).toEqual("0");
+    expect(positionA.averagePrice).toEqual("0");
+    expect(positionA.unrealized).toEqual("0");
+    expect(positionA.realized).toEqual("-0.5");
+    expect(positionA.frozenFunds).toEqual("2");
 
-    expect(positionB.netPosition.toString()).toEqual("12");
-    expect(positionB.averagePrice.toString()).toEqual("0.1");
-    expect(positionB.unrealized.toString()).toEqual("1.2");
-    expect(positionB.realized.toString()).toEqual("1.3");
-    expect(positionB.frozenFunds.toString()).toEqual("1.2");
+    expect(positionB.netPosition).toEqual("12");
+    expect(positionB.averagePrice).toEqual("0.1");
+    expect(positionB.unrealized).toEqual("1.2");
+    expect(positionB.realized).toEqual("1.3");
+    expect(positionB.frozenFunds).toEqual("1.2");
 
-    expect(positionC.netPosition.toString()).toEqual("2");
-    expect(positionC.averagePrice.toString()).toEqual("0.6");
-    expect(positionC.unrealized.toString()).toEqual("0.4");
-    expect(positionC.realized.toString()).toEqual("0.6");
-    expect(positionC.frozenFunds.toString()).toEqual("-0.8");
+    expect(positionC.netPosition).toEqual("2");
+    expect(positionC.averagePrice).toEqual("0.6");
+    expect(positionC.unrealized).toEqual("0.4");
+    expect(positionC.realized).toEqual("0.6");
+    expect(positionC.frozenFunds).toEqual("-0.8");
 
-    expect(frozenFundsTotal.frozenFunds.toString()).toEqual(bn(2.4).plus(validityBondSumInEth).toString());
+    expect(frozenFundsTotal.frozenFunds).toEqual(bn(2.4).plus(validityBondSumInEth).toString());
   });
 });
 
@@ -616,13 +616,13 @@ describe("server/getters/get-user-trading-positions#Scalar", () => {
 
     expect(tradingPositions.length).toEqual(1);
 
-    expect(tradingPositions[0].netPosition.toString()).toEqual("-3");
-    expect(tradingPositions[0].averagePrice.toString()).toEqual("205");
-    expect(tradingPositions[0].unrealized.toString()).toEqual("165");
-    expect(tradingPositions[0].realized.toString()).toEqual("458");
-    expect(tradingPositions[0].frozenFunds.toString()).toEqual("135");
+    expect(tradingPositions[0].netPosition).toEqual("-3");
+    expect(tradingPositions[0].averagePrice).toEqual("205");
+    expect(tradingPositions[0].unrealized).toEqual("165");
+    expect(tradingPositions[0].realized).toEqual("458");
+    expect(tradingPositions[0].frozenFunds).toEqual("135");
 
-    expect(frozenFundsTotal.frozenFunds.toString()).toEqual(bn(135).plus(validityBondSumInEth).toString());
+    expect(frozenFundsTotal.frozenFunds).toEqual(bn(135).plus(validityBondSumInEth).toString());
   });
 });
 
@@ -661,7 +661,7 @@ describe("server/getters/get-user-trading-positions frozenFundsTotal ignores val
       offset: null,
     });
 
-    expect(frozenFundsTotal.frozenFunds.toString()).toEqual(validityBondSumInEth.toString());
+    expect(frozenFundsTotal.frozenFunds).toEqual(validityBondSumInEth.toString());
   });
 
   it("get user's full position, ignoring a finalized market", async () => {
@@ -684,6 +684,6 @@ describe("server/getters/get-user-trading-positions frozenFundsTotal ignores val
 
     const validityBondSizeEthFromFinalizedMarket = bn(0.0128);
 
-    expect(frozenFundsTotal.frozenFunds.toString()).toEqual(validityBondSumInEth.minus(validityBondSizeEthFromFinalizedMarket).toString());
+    expect(frozenFundsTotal.frozenFunds).toEqual(validityBondSumInEth.minus(validityBondSizeEthFromFinalizedMarket).toString());
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "noImplicitAny": true,
     "noImplicitReturns": true,
     "noImplicitThis": true,
+    "noFallthroughCasesInSwitch": true,
     "outDir": "build",
     "rootDir": "src",
     "baseUrl": "./",

--- a/tslint.json
+++ b/tslint.json
@@ -105,6 +105,9 @@
     "no-shadowed-variable": false,
     "object-literal-sort-keys": false,
     "array-type": [true, "generic"],
+    "no-consecutive-blank-lines": false,
+    "no-trailing-whitespace": false,
+    "max-classes-per-file": false,
     "prefer-method-signature": true
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8665,9 +8665,10 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@3.1.6:
-  version "3.1.6"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.6.tgz#b6543a83cfc8c2befb3f4c8fba6896f5b0c9be68"
+typescript@3.3.3333:
+  version "3.3.3333"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.3.3333.tgz#171b2c5af66c59e9431199117a3bcadc66fdcfd6"
+  integrity sha512-JjSKsAfuHBE/fB2oZ8NxtRTk5iGcg6hkYXMnZ3Wc+b2RSqejEqTaem11mHASMnFilHrax3sLK0GDzcJrekZYLw==
 
 uglify-es@^3.3.4:
   version "3.3.9"


### PR DESCRIPTION
I'll write a better commit msg for the merge.

We'd like to merge this now so UI team can continue testing. After the merge I'll continue working on this:

1. clean up comments in financial-math and dimension-quantity
2. move financial-math to its own npm module or monorepo subdir ?? (might name it `augur-math`)
3. move dimension-quantity to its own npm module (might name it `ts-quantity`)

