### PR TITLE
Fix Outcomes/Outcome Descriptions for getAccountTransactionHistory

### DIFF
--- a/src/server/getters/get-account-transaction-history.ts
+++ b/src/server/getters/get-account-transaction-history.ts
@@ -87,7 +87,7 @@ async function transformQueryResults(db: Knex, queryResults: Array<AccountTransa
                     .from("outcomes")
                     .where({
                       marketId: queryResult.marketId, 
-                      outcome: payoutIndex 
+                      outcome: payoutIndex ,
                     });
                 });
                 queryResult.outcome = outcomeInfo[0].outcome;

--- a/src/server/getters/get-account-transaction-history.ts
+++ b/src/server/getters/get-account-transaction-history.ts
@@ -156,7 +156,7 @@ function queryBuy(db: Knex, qb: Knex.QueryBuilder, params: GetAccountTransaction
     "trades.price",
     db.raw("trades.amount as quantity"),
     db.raw("NULL as total"),
-    "trades.transactionHash")
+    "trades.blockNumber")
   .from("trades")
   .join("markets", "markets.marketId", "trades.marketId")
   .join("outcomes", function () {
@@ -200,7 +200,7 @@ function querySell(db: Knex, qb: Knex.QueryBuilder, params: GetAccountTransactio
     "trades.price",
     db.raw("trades.amount as quantity"),
     db.raw("NULL as total"),
-    "trades.transactionHash")
+    "trades.blockNumber")
   .from("trades")
   .join("markets", "markets.marketId", "trades.marketId")
   .join("outcomes", function () {
@@ -244,7 +244,7 @@ function queryCanceled(db: Knex, qb: Knex.QueryBuilder, params: GetAccountTransa
     db.raw("orders.price as price"),
     db.raw("orders.amount as quantity"),
     db.raw("'0' as total"),
-    "orders_canceled.transactionHash")
+    "orders_canceled.blockNumber")
   .from("orders_canceled")
   .join("markets", "markets.marketId", "orders.marketId")
   .join("orders", "orders.orderId", "orders_canceled.orderId")
@@ -288,7 +288,7 @@ function queryClaimMarketCreatorFees(db: Knex, qb: Knex.QueryBuilder, params: Ge
     db.raw("'0' as price"),
     db.raw("'0' as quantity"),
     db.raw("transfers.value as total"),
-    "transfers.transactionHash")
+    "transfers.blockNumber")
   .from("transfers")
   .join("markets", "markets.marketCreatorMailbox", "transfers.sender")
   .whereNull("transfers.recipient")
@@ -327,7 +327,7 @@ function queryClaimParticipationTokens(db: Knex, qb: Knex.QueryBuilder, params: 
     db.raw("'0' as price"),
     db.raw("'0' as quantity"),
     db.raw("participation_token_redeemed.reportingFeesReceived as total"),
-    "participation_token_redeemed.transactionHash")
+    "participation_token_redeemed.blockNumber")
   .from("participation_token_redeemed")
   .join("fee_windows", "fee_windows.feeWindow", "participation_token_redeemed.feeWindow")
   .where({
@@ -365,7 +365,7 @@ function queryClaimTradingProceeds(db: Knex, qb: Knex.QueryBuilder, params: GetA
     "outcomes.price",
     db.raw("trading_proceeds.numShares as quantity"),
     db.raw("trading_proceeds.numPayoutTokens as total"),
-    "trading_proceeds.transactionHash")
+    "trading_proceeds.blockNumber")
   .from("trading_proceeds")
   .join("markets", "markets.marketId", "trading_proceeds.marketId")
   .join("payouts", "payouts.marketId", "markets.marketId")
@@ -413,7 +413,7 @@ function queryClaimWinningCrowdsourcers(db: Knex, qb: Knex.QueryBuilder, params:
         db.raw("'0' as price"),
         db.raw("'0' as quantity"),
         db.raw("crowdsourcer_redeemed.reportingFeesReceived as total"),
-        "crowdsourcer_redeemed.transactionHash")
+        "crowdsourcer_redeemed.blockNumber")
       .from("crowdsourcer_redeemed")
       .join("markets", "markets.marketId", "crowdsourcers.marketId")
       .join("crowdsourcers", "crowdsourcers.crowdsourcerId", "crowdsourcer_redeemed.crowdsourcer")
@@ -460,7 +460,7 @@ function queryClaimWinningCrowdsourcers(db: Knex, qb: Knex.QueryBuilder, params:
         db.raw("'0' as price"),
         db.raw("'0' as quantity"),
         db.raw("crowdsourcer_redeemed.repReceived as total"),
-        "crowdsourcer_redeemed.transactionHash")
+        "crowdsourcer_redeemed.blockNumber")
       .from("crowdsourcer_redeemed")
       .join("markets", "markets.marketId", "crowdsourcers.marketId")
       .join("crowdsourcers", "crowdsourcers.crowdsourcerId", "crowdsourcer_redeemed.crowdsourcer")
@@ -509,7 +509,7 @@ function queryDispute(db: Knex, qb: Knex.QueryBuilder, params: GetAccountTransac
     db.raw("'0' as price"),
     db.raw("disputes.amountStaked as quantity"),
     db.raw("'0' as total"),
-    "disputes.transactionHash")
+    "disputes.blockNumber")
   .from("disputes")
   .join("crowdsourcers", "crowdsourcers.crowdsourcerId", "disputes.crowdsourcerId")
   .join("payouts", "payouts.payoutId", "crowdsourcers.payoutId")
@@ -550,7 +550,7 @@ function queryInitialReport(db: Knex, qb: Knex.QueryBuilder, params: GetAccountT
     db.raw("'0' as price"),
     "initial_reports.amountStaked as quantity",
     db.raw("'0' as total"),
-    "initial_reports.transactionHash")
+    "initial_reports.blockNumber")
   .from("initial_reports")
   .join("payouts", "payouts.payoutId", "initial_reports.payoutId")
   .join("markets", "markets.marketId", "initial_reports.marketId")
@@ -589,7 +589,7 @@ function queryMarketCreation(db: Knex, qb: Knex.QueryBuilder, params: GetAccount
     db.raw("'0' as price"), 
     db.raw("'0' as quantity"), 
     db.raw("'0' as total"), 
-    "markets.transactionHash")
+    db.raw("markets.creationBlockNumber as blockNumber"))
   .from("markets")
   .where({
     "markets.marketCreator": params.account,
@@ -628,7 +628,7 @@ function queryCompleteSets(db: Knex, qb: Knex.QueryBuilder, params: GetAccountTr
       db.raw("markets.numTicks as price"),
       db.raw("completeSets.numCompleteSets as quantity"),
       db.raw("'0' as total"),
-      "completeSets.transactionHash")
+      "completeSets.blockNumber")
     .from("completeSets")
     .join("markets", "markets.marketId", "completeSets.marketId")
     .where({
@@ -668,16 +668,14 @@ function queryCompleteSets(db: Knex, qb: Knex.QueryBuilder, params: GetAccountTr
       "markets.numTicks as price",
       "completeSets.numCompleteSets as quantity",
       db.raw("'0' as total"),
-      "completeSets.transactionHash")
+      "completeSets.blockNumber")
     .from("completeSets")
     .join("markets", "markets.marketId", "completeSets.marketId")
     .join("fee_windows", "fee_windows.universe", "markets.universe")
-    .join("transactionHashes", "transactionHashes.transactionHash", "completeSets.transactionHash")
-    .join("blocks", "blocks.blockNumber", "transactionHashes.blockNumber")
+    .join("blocks", "blocks.blockNumber", "completeSets.blockNumber")
     .whereRaw("blocks.timestamp between fee_windows.startTime and fee_windows.endTime")
     .where({
       "completeSets.eventName": "CompleteSetsSold",
-      "transactionHashes.removed": 0,
       "completeSets.account": params.account,
       "markets.universe": params.universe,
     });
@@ -751,8 +749,7 @@ export async function getAccountTransactionHistory(db: Knex, augur: {}, params: 
     }
     qb.as("data");
   })
-  .join("transactionHashes", "transactionHashes.transactionHash", "data.transactionHash")
-  .join("blocks", "transactionHashes.blockNumber", "blocks.blockNumber")
+  .join("blocks", "data.blockNumber", "blocks.blockNumber")
   .whereBetween("blocks.timestamp", [params.earliestTransactionTime, params.latestTransactionTime]);
 
   const accountTransactionHistory: Array<AccountTransactionHistoryRow<BigNumber>> = await queryModifier<AccountTransactionHistoryRow<BigNumber>>(db, query, "blocks.timestamp", "desc", params);

--- a/src/server/getters/get-account-transaction-history.ts
+++ b/src/server/getters/get-account-transaction-history.ts
@@ -156,6 +156,7 @@ function queryBuy(db: Knex, qb: Knex.QueryBuilder, params: GetAccountTransaction
     "trades.price",
     db.raw("trades.amount as quantity"),
     db.raw("NULL as total"),
+    "trades.transactionHash",
     "trades.blockNumber")
   .from("trades")
   .join("markets", "markets.marketId", "trades.marketId")
@@ -200,6 +201,7 @@ function querySell(db: Knex, qb: Knex.QueryBuilder, params: GetAccountTransactio
     "trades.price",
     db.raw("trades.amount as quantity"),
     db.raw("NULL as total"),
+    "trades.transactionHash",
     "trades.blockNumber")
   .from("trades")
   .join("markets", "markets.marketId", "trades.marketId")
@@ -244,6 +246,7 @@ function queryCanceled(db: Knex, qb: Knex.QueryBuilder, params: GetAccountTransa
     db.raw("orders.price as price"),
     db.raw("orders.amount as quantity"),
     db.raw("'0' as total"),
+    "orders_canceled.transactionHash",
     "orders_canceled.blockNumber")
   .from("orders_canceled")
   .join("markets", "markets.marketId", "orders.marketId")
@@ -288,6 +291,7 @@ function queryClaimMarketCreatorFees(db: Knex, qb: Knex.QueryBuilder, params: Ge
     db.raw("'0' as price"),
     db.raw("'0' as quantity"),
     db.raw("transfers.value as total"),
+    "transfers.transactionHash",
     "transfers.blockNumber")
   .from("transfers")
   .join("markets", "markets.marketCreatorMailbox", "transfers.sender")
@@ -327,6 +331,7 @@ function queryClaimParticipationTokens(db: Knex, qb: Knex.QueryBuilder, params: 
     db.raw("'0' as price"),
     db.raw("'0' as quantity"),
     db.raw("participation_token_redeemed.reportingFeesReceived as total"),
+    "participation_token_redeemed.transactionHash",
     "participation_token_redeemed.blockNumber")
   .from("participation_token_redeemed")
   .join("fee_windows", "fee_windows.feeWindow", "participation_token_redeemed.feeWindow")
@@ -365,6 +370,7 @@ function queryClaimTradingProceeds(db: Knex, qb: Knex.QueryBuilder, params: GetA
     "outcomes.price",
     db.raw("trading_proceeds.numShares as quantity"),
     db.raw("trading_proceeds.numPayoutTokens as total"),
+    "trading_proceeds.transactionHash",
     "trading_proceeds.blockNumber")
   .from("trading_proceeds")
   .join("markets", "markets.marketId", "trading_proceeds.marketId")
@@ -413,6 +419,7 @@ function queryClaimWinningCrowdsourcers(db: Knex, qb: Knex.QueryBuilder, params:
         db.raw("'0' as price"),
         db.raw("'0' as quantity"),
         db.raw("crowdsourcer_redeemed.reportingFeesReceived as total"),
+        "crowdsourcer_redeemed.transactionHash",
         "crowdsourcer_redeemed.blockNumber")
       .from("crowdsourcer_redeemed")
       .join("markets", "markets.marketId", "crowdsourcers.marketId")
@@ -460,6 +467,7 @@ function queryClaimWinningCrowdsourcers(db: Knex, qb: Knex.QueryBuilder, params:
         db.raw("'0' as price"),
         db.raw("'0' as quantity"),
         db.raw("crowdsourcer_redeemed.repReceived as total"),
+        "crowdsourcer_redeemed.transactionHash",
         "crowdsourcer_redeemed.blockNumber")
       .from("crowdsourcer_redeemed")
       .join("markets", "markets.marketId", "crowdsourcers.marketId")
@@ -509,6 +517,7 @@ function queryDispute(db: Knex, qb: Knex.QueryBuilder, params: GetAccountTransac
     db.raw("'0' as price"),
     db.raw("disputes.amountStaked as quantity"),
     db.raw("'0' as total"),
+    "disputes.transactionHash",
     "disputes.blockNumber")
   .from("disputes")
   .join("crowdsourcers", "crowdsourcers.crowdsourcerId", "disputes.crowdsourcerId")
@@ -550,6 +559,7 @@ function queryInitialReport(db: Knex, qb: Knex.QueryBuilder, params: GetAccountT
     db.raw("'0' as price"),
     "initial_reports.amountStaked as quantity",
     db.raw("'0' as total"),
+    "initial_reports.transactionHash",
     "initial_reports.blockNumber")
   .from("initial_reports")
   .join("payouts", "payouts.payoutId", "initial_reports.payoutId")
@@ -589,6 +599,7 @@ function queryMarketCreation(db: Knex, qb: Knex.QueryBuilder, params: GetAccount
     db.raw("'0' as price"), 
     db.raw("'0' as quantity"), 
     db.raw("'0' as total"), 
+    "markets.transactionHash",
     db.raw("markets.creationBlockNumber as blockNumber"))
   .from("markets")
   .where({
@@ -628,6 +639,7 @@ function queryCompleteSets(db: Knex, qb: Knex.QueryBuilder, params: GetAccountTr
       db.raw("markets.numTicks as price"),
       db.raw("completeSets.numCompleteSets as quantity"),
       db.raw("'0' as total"),
+      "completeSets.transactionHash",
       "completeSets.blockNumber")
     .from("completeSets")
     .join("markets", "markets.marketId", "completeSets.marketId")
@@ -668,6 +680,7 @@ function queryCompleteSets(db: Knex, qb: Knex.QueryBuilder, params: GetAccountTr
       "markets.numTicks as price",
       "completeSets.numCompleteSets as quantity",
       db.raw("'0' as total"),
+      "completeSets.transactionHash",
       "completeSets.blockNumber")
     .from("completeSets")
     .join("markets", "markets.marketId", "completeSets.marketId")

--- a/src/server/getters/get-account-transaction-history.ts
+++ b/src/server/getters/get-account-transaction-history.ts
@@ -128,93 +128,191 @@ async function transformQueryResults(db: Knex, queryResults: Array<AccountTransa
 }
 
 function queryBuy(db: Knex, qb: Knex.QueryBuilder, params: GetAccountTransactionHistoryParamsType) {
-  return qb.select(
-    db.raw("? as action", Action.BUY),
-    db.raw("'ETH' as coin"),
-    db.raw("'Buy order' as details"),
-    "markets.marketId",
-    "trades.marketCreatorFees",
-    "markets.marketType",
-    "markets.maxPrice",
-    db.raw("NULL as numPayoutTokens"),
-    db.raw("NULL as numShares"),
-    "trades.reporterFees",
-    "markets.scalarDenomination",
-    db.raw("NULL as fee"),
-    "markets.shortDescription as marketDescription",
-    "outcomes.outcome",
-    db.raw("outcomes.description as outcomeDescription"),
-    db.raw("NULL as payout0"),
-    db.raw("NULL as payout1"),
-    db.raw("NULL as payout2"),
-    db.raw("NULL as payout3"),
-    db.raw("NULL as payout4"),
-    db.raw("NULL as payout5"),
-    db.raw("NULL as payout6"),
-    db.raw("NULL as payout7"),
-    db.raw("NULL as isInvalid"),
-    "trades.price",
-    db.raw("trades.amount as quantity"),
-    db.raw("NULL as total"),
-    "trades.transactionHash",
-    "trades.blockNumber")
-  .from("trades")
-  .join("markets", "markets.marketId", "trades.marketId")
-  .join("outcomes", function () {
-    this
-      .on("outcomes.marketId", "trades.marketId")
-      .on("outcomes.outcome", "trades.outcome");
-  })
-  .where({
-    "trades.orderType": "buy",
-    "trades.creator": params.account,
-    "markets.universe": params.universe,
+  qb.union((qb: Knex.QueryBuilder) => {
+    qb.select(
+      db.raw("? as action", Action.BUY),
+      db.raw("'ETH' as coin"),
+      db.raw("'Buy order' as details"),
+      "markets.marketId",
+      "trades.marketCreatorFees",
+      "markets.marketType",
+      "markets.maxPrice",
+      db.raw("NULL as numPayoutTokens"),
+      db.raw("NULL as numShares"),
+      "trades.reporterFees",
+      "markets.scalarDenomination",
+      db.raw("NULL as fee"),
+      "markets.shortDescription as marketDescription",
+      "outcomes.outcome",
+      db.raw("outcomes.description as outcomeDescription"),
+      db.raw("NULL as payout0"),
+      db.raw("NULL as payout1"),
+      db.raw("NULL as payout2"),
+      db.raw("NULL as payout3"),
+      db.raw("NULL as payout4"),
+      db.raw("NULL as payout5"),
+      db.raw("NULL as payout6"),
+      db.raw("NULL as payout7"),
+      db.raw("NULL as isInvalid"),
+      "trades.price",
+      db.raw("trades.amount as quantity"),
+      db.raw("NULL as total"),
+      "trades.transactionHash",
+      "trades.blockNumber")
+    .from("trades")
+    .join("markets", "markets.marketId", "trades.marketId")
+    .join("outcomes", function () {
+      this
+        .on("outcomes.marketId", "trades.marketId")
+        .on("outcomes.outcome", "trades.outcome");
+    })
+    .where({
+      "trades.orderType": "buy",
+      "trades.creator": params.account,
+      "markets.universe": params.universe,
+    });
   });
+
+  qb.union((qb: Knex.QueryBuilder) => {
+    qb.select(
+      db.raw("? as action", Action.BUY),
+      db.raw("'ETH' as coin"),
+      db.raw("'Buy order' as details"),
+      "markets.marketId",
+      "trades.marketCreatorFees",
+      "markets.marketType",
+      "markets.maxPrice",
+      db.raw("NULL as numPayoutTokens"),
+      db.raw("NULL as numShares"),
+      "trades.reporterFees",
+      "markets.scalarDenomination",
+      db.raw("NULL as fee"),
+      "markets.shortDescription as marketDescription",
+      "outcomes.outcome",
+      db.raw("outcomes.description as outcomeDescription"),
+      db.raw("NULL as payout0"),
+      db.raw("NULL as payout1"),
+      db.raw("NULL as payout2"),
+      db.raw("NULL as payout3"),
+      db.raw("NULL as payout4"),
+      db.raw("NULL as payout5"),
+      db.raw("NULL as payout6"),
+      db.raw("NULL as payout7"),
+      db.raw("NULL as isInvalid"),
+      "trades.price",
+      db.raw("trades.amount as quantity"),
+      db.raw("NULL as total"),
+      "trades.transactionHash",
+      "trades.blockNumber")
+    .from("trades")
+    .join("markets", "markets.marketId", "trades.marketId")
+    .join("outcomes", function () {
+      this
+        .on("outcomes.marketId", "trades.marketId")
+        .on("outcomes.outcome", "trades.outcome");
+    })
+    .where({
+      "trades.orderType": "sell",
+      "trades.filler": params.account,
+      "markets.universe": params.universe,
+    });
+  });
+
+  return qb;
 }
 
 function querySell(db: Knex, qb: Knex.QueryBuilder, params: GetAccountTransactionHistoryParamsType) {
-  return qb.select(
-    db.raw("? as action", Action.SELL),
-    db.raw("'ETH' as coin"),
-    db.raw("'Sell order' as details"),
-    "markets.marketId",
-    "trades.marketCreatorFees",
-    "markets.marketType",
-    db.raw("NULL as maxPrice"),
-    db.raw("NULL as numPayoutTokens"),
-    db.raw("NULL as numShares"),
-    "trades.reporterFees",
-    "markets.scalarDenomination",
-    db.raw("NULL as fee"),
-    "markets.shortDescription as marketDescription",
-    "outcomes.outcome",
-    db.raw("outcomes.description as outcomeDescription"),
-    db.raw("NULL as payout0"),
-    db.raw("NULL as payout1"),
-    db.raw("NULL as payout2"),
-    db.raw("NULL as payout3"),
-    db.raw("NULL as payout4"),
-    db.raw("NULL as payout5"),
-    db.raw("NULL as payout6"),
-    db.raw("NULL as payout7"),
-    db.raw("NULL as isInvalid"),
-    "trades.price",
-    db.raw("trades.amount as quantity"),
-    db.raw("NULL as total"),
-    "trades.transactionHash",
-    "trades.blockNumber")
-  .from("trades")
-  .join("markets", "markets.marketId", "trades.marketId")
-  .join("outcomes", function () {
-    this
-      .on("outcomes.marketId", "trades.marketId")
-      .on("outcomes.outcome", "trades.outcome");
-  })
-  .where({
-    "trades.orderType": "sell",
-    "trades.creator": params.account,
-    "markets.universe": params.universe,
+  qb.union((qb: Knex.QueryBuilder) => {
+    qb.select(
+      db.raw("? as action", Action.SELL),
+      db.raw("'ETH' as coin"),
+      db.raw("'Sell order' as details"),
+      "markets.marketId",
+      "trades.marketCreatorFees",
+      "markets.marketType",
+      db.raw("NULL as maxPrice"),
+      db.raw("NULL as numPayoutTokens"),
+      db.raw("NULL as numShares"),
+      "trades.reporterFees",
+      "markets.scalarDenomination",
+      db.raw("NULL as fee"),
+      "markets.shortDescription as marketDescription",
+      "outcomes.outcome",
+      db.raw("outcomes.description as outcomeDescription"),
+      db.raw("NULL as payout0"),
+      db.raw("NULL as payout1"),
+      db.raw("NULL as payout2"),
+      db.raw("NULL as payout3"),
+      db.raw("NULL as payout4"),
+      db.raw("NULL as payout5"),
+      db.raw("NULL as payout6"),
+      db.raw("NULL as payout7"),
+      db.raw("NULL as isInvalid"),
+      "trades.price",
+      db.raw("trades.amount as quantity"),
+      db.raw("NULL as total"),
+      "trades.transactionHash",
+      "trades.blockNumber")
+    .from("trades")
+    .join("markets", "markets.marketId", "trades.marketId")
+    .join("outcomes", function () {
+      this
+        .on("outcomes.marketId", "trades.marketId")
+        .on("outcomes.outcome", "trades.outcome");
+    })
+    .where({
+      "trades.orderType": "sell",
+      "trades.creator": params.account,
+      "markets.universe": params.universe,
+    });
   });
+
+  qb.union((qb: Knex.QueryBuilder) => {
+    qb.select(
+      db.raw("? as action", Action.SELL),
+      db.raw("'ETH' as coin"),
+      db.raw("'Sell order' as details"),
+      "markets.marketId",
+      "trades.marketCreatorFees",
+      "markets.marketType",
+      db.raw("NULL as maxPrice"),
+      db.raw("NULL as numPayoutTokens"),
+      db.raw("NULL as numShares"),
+      "trades.reporterFees",
+      "markets.scalarDenomination",
+      db.raw("NULL as fee"),
+      "markets.shortDescription as marketDescription",
+      "outcomes.outcome",
+      db.raw("outcomes.description as outcomeDescription"),
+      db.raw("NULL as payout0"),
+      db.raw("NULL as payout1"),
+      db.raw("NULL as payout2"),
+      db.raw("NULL as payout3"),
+      db.raw("NULL as payout4"),
+      db.raw("NULL as payout5"),
+      db.raw("NULL as payout6"),
+      db.raw("NULL as payout7"),
+      db.raw("NULL as isInvalid"),
+      "trades.price",
+      db.raw("trades.amount as quantity"),
+      db.raw("NULL as total"),
+      "trades.transactionHash",
+      "trades.blockNumber")
+    .from("trades")
+    .join("markets", "markets.marketId", "trades.marketId")
+    .join("outcomes", function () {
+      this
+        .on("outcomes.marketId", "trades.marketId")
+        .on("outcomes.outcome", "trades.outcome");
+    })
+    .where({
+      "trades.orderType": "buy",
+      "trades.filler": params.account,
+      "markets.universe": params.universe,
+    });
+  });
+
+  return qb;
 }
 
 function queryCanceled(db: Knex, qb: Knex.QueryBuilder, params: GetAccountTransactionHistoryParamsType) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -750,6 +750,7 @@ export interface AccountTransactionHistoryRow<BigNumberType> {
   coin: string;
   details: string;
   fee: BigNumberType;
+  marketId: string;
   marketDescription: string;
   marketType: string;
   outcome: number;
@@ -765,6 +766,7 @@ export interface AccountTransactionHistoryRow<BigNumberType> {
   isInvalid: boolean;
   price: BigNumberType;
   quantity: BigNumberType;
+  scalarDenomination: string;
   timestamp: number;
   total: BigNumberType;
   transactionHash: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3635,9 +3635,10 @@ ethrpc@6.1.3:
     request "2.85.0"
     websocket "1.0.26"
 
-ethrpc@^6.1.2:
-  version "6.1.2"
-  resolved "https://registry.yarnpkg.com/ethrpc/-/ethrpc-6.1.2.tgz#9d38985d58bc9694afc4900802f2c4c15be62197"
+ethrpc@6.1.4:
+  version "6.1.4"
+  resolved "https://registry.yarnpkg.com/ethrpc/-/ethrpc-6.1.4.tgz#98a635f501147d550215ee6db9019c26dc2ef0b5"
+  integrity sha512-TFz6irbVQvtM5ReeOQuvuq6lQkDpQplwPRrUvBxXy0eA7AVKmSv9KlDIzwHPwGNpkw/04fgAwyA/ohJxkSGlwA==
   dependencies:
     async "2.6.0"
     bignumber.js "6.0.0"


### PR DESCRIPTION
Fixes https://github.com/AugurProject/augur/issues/1515, where outcomes/outcome descriptions were sometimes getting returned as null (for example, yes/no markets or scalar markets).

In cases of market creation, particpation token, or complete set txs, both `outcome` & `outcomeDescription` will still be null. `outcome` can also be set to null if the outcome is invalid (however, `outcomeDescription` will be set to "Invalid").