### PR TITLE
Fixes #848

### DIFF
--- a/src/runServer.ts
+++ b/src/runServer.ts
@@ -19,10 +19,12 @@ const isWarpSync = process.env.IS_WARP_SYNC  === "true";
 const maxRetries = process.env.MAX_REQUEST_RETRIES || 3; // default maxRetries to 3, because certain Ethereum RPC servers may frequently return transient errors and require non-zero ethrpc maxRetries to function sanely. Eg.  `geth --syncmode=light` frequently returns result "0x", signifying no data, for requests which should have data. Note that augur-app bypasses this entrypoint and has its own default for MAX_REQUEST_RETRIES.
 
 const maxSystemRetries = process.env.MAX_SYSTEM_RETRIES || "3";
+const blocksPerChunk = process.env.BLOCKS_PER_CHUNK || 720;
 const propagationDelayWaitMillis = process.env.DELAY_WAIT_MILLIS;
 const networkConfig = NetworkConfiguration.create(networkName, false);
 
 let config = networkConfig;
+if (blocksPerChunk) config =  Object.assign({}, config, { blocksPerChunk });
 if (maxRetries) config = Object.assign({}, config, { maxRetries });
 if (propagationDelayWaitMillis) config = Object.assign({}, config, { propagationDelayWaitMillis });
 const retries: number = parseInt(maxSystemRetries || "1", 10);


### PR DESCRIPTION
Allow user to specify the number of blocks fetched at once, which lets
them set a configuration to a value that makes sense for their system.
For Infura's limit of 1000 logs returned, tune this value to 10.

Default Value: 720 blocks per chunk