### PR TITLE
Add blockNumber, logIndex to DB table outcome_value_timeseries

### DIFF
--- a/src/blockchain/log-processors/market-finalized.ts
+++ b/src/blockchain/log-processors/market-finalized.ts
@@ -17,7 +17,7 @@ export async function processMarketFinalizedLog(augur: Augur, log: FormattedEven
     await db("markets").where({ marketId: log.market }).update({ finalizationBlockNumber: log.blockNumber });
     await flagMarketsNeedingMigration(db, log.market, log.universe);
     await refreshMarketMailboxEthBalance(db, augur, log.market);
-    await updateOutcomeValuesFromFinalization(db, augur, log.market, log.transactionHash);
+    await updateOutcomeValuesFromFinalization(db, augur, log.market, log.transactionHash, log.blockNumber, log.logIndex);
     await updateCategoryAggregationsOnMarketFinalized({ db, marketId: log.market });
   };
 }

--- a/src/blockchain/log-processors/order-filled/index.ts
+++ b/src/blockchain/log-processors/order-filled/index.ts
@@ -81,7 +81,7 @@ export async function processOrderFilledLog(augur: Augur, log: FormattedEventLog
     await updateOrder(db, augur, marketId, orderId, amount, price, numCreatorShares, numCreatorTokens);
 
     if (!finalized) {
-      await updateOutcomeValueFromOrders(db, marketId, outcome, log.transactionHash, price);
+      await updateOutcomeValueFromOrders(db, marketId, outcome, log.transactionHash, log.blockNumber, log.logIndex, price);
     }
 
     await updateProfitLoss(db, marketId, orderType === "buy" ? amount : amount.negated(), orderCreator, outcome, price, log.transactionHash, log.blockNumber, log.logIndex, tradesRowBigNumber);

--- a/src/blockchain/log-processors/profit-loss/update-outcome-value.ts
+++ b/src/blockchain/log-processors/profit-loss/update-outcome-value.ts
@@ -20,11 +20,13 @@ interface PayoutAndMarket<BigNumberType> extends PayoutNumerators<BigNumberType>
   numTicks: BigNumber;
 }
 
-export async function updateOutcomeValueFromOrders(db: Knex, marketId: Address, outcome: number, transactionHash: string, value: BigNumber): Promise<void> {
+export async function updateOutcomeValueFromOrders(db: Knex, marketId: Address, outcome: number, transactionHash: string, blockNumber: number, logIndex: number, value: BigNumber): Promise<void> {
   await db
     .insert({
       marketId,
       transactionHash,
+      blockNumber,
+      logIndex,
       outcome,
       value: value.toString(),
       timestamp: getCurrentTime(),
@@ -32,7 +34,7 @@ export async function updateOutcomeValueFromOrders(db: Knex, marketId: Address, 
     .into("outcome_value_timeseries");
 }
 
-export async function updateOutcomeValuesFromFinalization(db: Knex, augur: Augur, marketId: Address, transactionHash: string): Promise<void> {
+export async function updateOutcomeValuesFromFinalization(db: Knex, augur: Augur, marketId: Address, transactionHash: string, blockNumber: number, logIndex: number): Promise<void> {
   const payouts: PayoutAndMarket<BigNumber> = await db
     .first(["payouts.payout0", "payouts.payout1", "payouts.payout2", "payouts.payout3", "payouts.payout4", "payouts.payout5", "payouts.payout6", "payouts.payout7", "markets.minPrice", "markets.maxPrice", "markets.numTicks"])
     .from("payouts")
@@ -54,6 +56,8 @@ export async function updateOutcomeValuesFromFinalization(db: Knex, augur: Augur
       insertValues.push({
         marketId,
         transactionHash,
+        blockNumber,
+        logIndex,
         outcome: i,
         value: value.toString(),
         timestamp,

--- a/src/migrations/20190422154621_add_blockNumber_logIndex_to_outcome_value_timeseries.ts
+++ b/src/migrations/20190422154621_add_blockNumber_logIndex_to_outcome_value_timeseries.ts
@@ -1,0 +1,18 @@
+import * as Knex from "knex";
+
+exports.up = async (knex: Knex): Promise<any> => {
+  const addBlockNumber = knex.schema.hasColumn("outcome_value_timeseries", "blockNumber").then(async (exists) => {
+    if (!exists) await knex.schema.table("outcome_value_timeseries", (t) => t.specificType("blockNumber", "integer NOT NULL DEFAULT 0 CONSTRAINT nonnegativeBlockNumber CHECK (\"blockNumber\" >= 0)"));
+  });
+  const addLogIndex = knex.schema.hasColumn("outcome_value_timeseries", "logIndex").then(async (exists) => {
+    if (!exists) await knex.schema.table("outcome_value_timeseries", (t) => t.specificType("logIndex", "integer NOT NULL DEFAULT 0 CONSTRAINT nonnegativeLogIndex CHECK (\"logIndex\" >= 0)"));
+  });
+  return Promise.all([addBlockNumber, addLogIndex]);
+};
+
+exports.down = async (knex: Knex): Promise<any> => {
+  return knex.schema.table("outcome_value_timeseries", (table: Knex.CreateTableBuilder): void => {
+    table.dropColumn("blockNumber");
+    table.dropColumn("logIndex");
+  });
+};

--- a/src/server/getters/get-profit-loss.ts
+++ b/src/server/getters/get-profit-loss.ts
@@ -39,6 +39,8 @@ export function getDefaultOVTimeseries(): OutcomeValueTimeseries {
     outcome: 0,
     value: ZERO,
     transactionHash: "",
+    blockNumber: 0,
+    logIndex: 0,
   };
 }
 
@@ -66,6 +68,8 @@ export interface OutcomeValueTimeseries extends Timestamped {
   outcome: number;
   value: BigNumber;
   transactionHash: string;
+  blockNumber: number;
+  logIndex: number;
 }
 
 // ProfitLossResult is the profit or loss result, at a particular point in
@@ -211,7 +215,9 @@ async function queryOutcomeValueTimeseries(db: Knex, now: number, params: GetPro
   const query = db("outcome_value_timeseries")
     .select("outcome_value_timeseries.*", "markets.universe")
     .join("markets", "outcome_value_timeseries.marketId", "markets.marketId")
-    .orderBy("timestamp");
+    .orderBy("timestamp", "asc")
+    .orderBy("blockNumber", "asc")
+    .orderBy("logIndex", "asc");
 
   if (params.marketId !== null) query.where("outcome_value_timeseries.marketId", params.marketId);
   if (params.startTime) query.where("timestamp", ">=", params.startTime);


### PR DESCRIPTION
The DB table outcome_value_timeseries uses timestamp as the sort column, but
trades in the same block may have the same timestamp, preventing clients of
outcome_value_timeseries from determining the correct trade order.

Also sort by (timestamp, blockNumber, logIndex) instead of just timestamp in
queryOutcomeValueTimeseries, the only client of outcome_value_timeseries.

Fixes AugurProject/augur#1634