### PR TITLE
Fixes #1849

### DIFF
--- a/src/blockchain/log-processors/profit-loss/update-profit-loss.ts
+++ b/src/blockchain/log-processors/profit-loss/update-profit-loss.ts
@@ -46,7 +46,7 @@ export async function updateProfitLossClaimProceeds(db: Knex, marketId: Address,
       .first(["position"])
       .from("wcl_profit_loss_timeseries")
       .where({ account, marketId, outcome })
-      .orderByRaw(`"blockNumber" DESC, "logIndex" DESC`);
+      .orderByRaw(`"blockNumber" DESC, "logIndex" DESC, "rowid" DESC`);
     const lastPosition = lastData ? lastData.position : ZERO;
     if (!lastPosition.eq(ZERO)) {
       const price = lastPosition.lt(ZERO) ? totalPayout.minus(outcomeValues[outcome]) : outcomeValues[outcome];
@@ -79,7 +79,7 @@ export async function updateProfitLoss(db: Knex, marketId: Address, positionDelt
     .first(["price", "position", "profit", "frozenFunds", "realizedCost"])
     .from("wcl_profit_loss_timeseries")
     .where({ account, marketId, outcome })
-    .orderByRaw(`"blockNumber" DESC, "logIndex" DESC`);
+    .orderByRaw(`"blockNumber" DESC, "logIndex" DESC, "rowid" DESC`);
 
   const netPosition: Shares = prevData ? new Shares(prevData.position) : Shares.ZERO;
   const averageTradePriceMinusMinPriceForOpenPosition = prevData ? new Price(prevData.price) : Price.ZERO;


### PR DESCRIPTION
During self trades, there are two PL rows generated for one logIndex.
Since we weren't taking this into accoutn in the query, the natural
ordering of SQLite meant the `limit 1` was picking up the first half
of the trade via the first PL row.

Added ordering by rowid DESC in order to make sure the LAST trade
generates the PL we are using to determine how the positions change over
time.