### PR TITLE
Handle open orders and self-trades in frozen funds

### DIFF
--- a/src/blockchain/log-processors/order-canceled.ts
+++ b/src/blockchain/log-processors/order-canceled.ts
@@ -1,15 +1,18 @@
 import Augur from "augur.js";
-import * as Knex from "knex";
 import { BigNumber } from "bignumber.js";
-import { Bytes32, FormattedEventLog, OrderState } from "../../types";
-import { augurEmitter } from "../../events";
+import * as Knex from "knex";
 import { SubscriptionEventNames } from "../../constants";
+import { augurEmitter } from "../../events";
+import { getDefaultPLTimeseries, ProfitLossTimeseriesRow } from "../../server/getters/get-profit-loss";
+import { Bytes32, FormattedEventLog, OrdersRow, OrderState } from "../../types";
+import { FrozenFunds, getFrozenFundsAfterEventForOneOutcome } from "./profit-loss/frozen-funds";
+import { getCurrentTime } from "../process-block";
 
 interface MarketIDAndOutcomeAndPrice {
   marketId: Bytes32;
   outcome: number;
   price: BigNumber;
-  orderType: string|number;
+  orderType: string | number;
   orderCreator: string;
   sharesEscrowed: BigNumber;
 }
@@ -20,10 +23,55 @@ interface MarketNumOutcomes {
 
 export async function processOrderCanceledLog(augur: Augur, log: FormattedEventLog) {
   return async (db: Knex) => {
+    const { tokensEscrowed }: Pick<OrdersRow<BigNumber>, "tokensEscrowed"> = await db
+      .first("orders.tokensEscrowed")
+      .from("orders")
+      .where({ orderId: log.orderId })
+      .orderByRaw(`"blockNumber" DESC, "logIndex" DESC`);
+    if (!tokensEscrowed) throw new Error(`order id not found: ${{ orderId: log.orderId }}`);
+
+    const prevProfitLoss: undefined | ProfitLossTimeseriesRow<BigNumber> = await db
+      .first("wcl_profit_loss_timeseries.*")
+      .from("wcl_profit_loss_timeseries")
+      .join("orders", function(this: any) {
+        this.on(function(this: any) {
+          this.on("wcl_profit_loss_timeseries.marketId", "=", "orders.marketId");
+          this.andOn("wcl_profit_loss_timeseries.outcome", "=", "wcl_profit_loss_timeseries.outcome");
+        });
+      })
+      .whereRaw("wcl_profit_loss_timeseries.account = orders.orderCreator")
+      .where({ orderId: log.orderId })
+      .orderByRaw(`"blockNumber" DESC, "logIndex" DESC, "wcl_profit_loss_timeseries.rowid" DESC`);
+
+    if (!prevProfitLoss) throw new Error(`expected to find previous wcl_profit_loss_timeseries on order cancel orderId=${log.orderId}`);
+
     const orderTypeLabel = log.orderType === "0" ? "buy" : "sell";
     await db.from("orders").where("orderId", log.orderId).update({ orderState: OrderState.CANCELED });
-    await  db.into("orders_canceled").insert({ orderId: log.orderId, transactionHash: log.transactionHash, logIndex: log.logIndex, blockNumber: log.blockNumber });
-    const ordersRow: MarketIDAndOutcomeAndPrice = await  db.first("marketId", "outcome", "price", "sharesEscrowed", "orderCreator").from("orders").where("orderId", log.orderId);
+    await db.into("orders_canceled").insert({ orderId: log.orderId, transactionHash: log.transactionHash, logIndex: log.logIndex, blockNumber: log.blockNumber });
+
+    const nextFrozenFunds: FrozenFunds = getFrozenFundsAfterEventForOneOutcome({
+      frozenFundsBeforeEvent: prevProfitLoss,
+      event: {
+        orderCanceledEvent: true,
+        tokensEscrowed,
+      },
+    });
+
+    const nextProfitLoss: ProfitLossTimeseriesRow<string> = Object.assign({}, prevProfitLoss, {
+      timestamp: getCurrentTime(),
+      price: prevProfitLoss.price.toString(),
+      position: prevProfitLoss.position.toString(),
+      quantityOpened: prevProfitLoss.quantityOpened.toString(),
+      profit: prevProfitLoss.profit.toString(),
+      realizedCost: prevProfitLoss.realizedCost.toString(),
+      frozenFunds: nextFrozenFunds.frozenFunds.toString(),
+      blockNumber: log.blockNumber,
+      logIndex: log.logIndex,
+      transactionHash: log.transactionHash,
+    });
+    await db.insert(nextProfitLoss).into("wcl_profit_loss_timeseries");
+
+    const ordersRow: MarketIDAndOutcomeAndPrice = await db.first("marketId", "outcome", "price", "sharesEscrowed", "orderCreator").from("orders").where("orderId", log.orderId);
     ordersRow.orderType = orderTypeLabel;
     augurEmitter.emit(SubscriptionEventNames.OrderCanceled, Object.assign({}, log, ordersRow));
   };
@@ -31,6 +79,9 @@ export async function processOrderCanceledLog(augur: Augur, log: FormattedEventL
 
 export async function processOrderCanceledLogRemoval(augur: Augur, log: FormattedEventLog) {
   return async (db: Knex) => {
+    await db("wcl_profit_loss_timeseries")
+      .delete()
+      .where({ transactionHash: log.transactionHash });
     const orderTypeLabel = log.orderType === "0" ? "buy" : "sell";
     await db.from("orders").where("orderId", log.orderId).update({ orderState: OrderState.OPEN });
     await db.from("orders_canceled").where("orderId", log.orderId).delete();

--- a/src/blockchain/log-processors/order-created.ts
+++ b/src/blockchain/log-processors/order-created.ts
@@ -1,28 +1,55 @@
 import Augur from "augur.js";
-import * as Knex from "knex";
 import { BigNumber } from "bignumber.js";
-import { Address, FormattedEventLog, MarketsRow, OrdersRow, TokensRow, OrderState } from "../../types";
+import * as Knex from "knex";
+import { QueryBuilder } from "knex";
+import { BN_WEI_PER_ETHER, SubscriptionEventNames } from "../../constants";
 import { augurEmitter } from "../../events";
+import { getDefaultPLTimeseries, ProfitLossTimeseriesRow } from "../../server/getters/get-profit-loss";
+import { Address, FormattedEventLog, MarketsRow, OrdersRow, OrderState, TokensRow } from "../../types";
 import { fixedPointToDecimal, numTicksToTickSize } from "../../utils/convert-fixed-point-to-decimal";
 import { formatOrderAmount, formatOrderPrice } from "../../utils/format-order";
-import { BN_WEI_PER_ETHER, SubscriptionEventNames } from "../../constants";
-import { QueryBuilder } from "knex";
-import { updateProfitLossRemoveRow } from "./profit-loss/update-profit-loss";
+import { FrozenFunds, getFrozenFundsAfterEventForOneOutcome } from "./profit-loss/frozen-funds";
+import { getCurrentTime } from "../process-block";
 
 export async function processOrderCreatedLog(augur: Augur, log: FormattedEventLog) {
-  return async(db: Knex) => {
+  return async (db: Knex) => {
     const amount: BigNumber = new BigNumber(log.amount, 10);
     const price: BigNumber = new BigNumber(log.price, 10);
     const orderType: string = log.orderType;
     const moneyEscrowed: BigNumber = new BigNumber(log.moneyEscrowed, 10);
     const sharesEscrowed: BigNumber = new BigNumber(log.sharesEscrowed, 10);
     const shareToken: Address = log.shareToken;
-    const tokensRow: TokensRow|undefined = await db.first("marketId", "outcome").from("tokens").where({ contractAddress: shareToken });
+    const tokensRow: TokensRow | undefined = await db.first("marketId", "outcome").from("tokens").where({ contractAddress: shareToken });
     if (!tokensRow) throw new Error(`market and outcome not found for shareToken ${shareToken} (${log.transactionHash}`);
     const marketId = tokensRow.marketId;
     const outcome = tokensRow.outcome!;
     const marketsRow: MarketsRow<BigNumber> = await db.first("minPrice", "maxPrice", "numTicks", "numOutcomes").from("markets").where({ marketId });
     if (!marketsRow) throw new Error(`market not found: ${marketId}`);
+
+    const prevProfitLossQuery: undefined | ProfitLossTimeseriesRow<BigNumber> =
+      await db
+      .first()
+      .from("wcl_profit_loss_timeseries")
+      .where({ account: log.creator, marketId, outcome })
+      .orderByRaw(`"blockNumber" DESC, "logIndex" DESC, "rowid" DESC`);
+
+    const prevProfitLoss: ProfitLossTimeseriesRow<BigNumber> = prevProfitLossQuery || Object.assign((() => {
+      const pl = getDefaultPLTimeseries();
+      // These market properties are in ProfitLossTimeseries, but not
+      // ProfitLossTimeseriesRow, and need to be deleted, or inserting
+      // into wcl_profit_loss_timeseries below will throw error.
+      delete pl.minPrice;
+      delete pl.maxPrice;
+      delete pl.numOutcomes;
+      return pl;
+    })(), {
+      account: log.creator,
+      marketId,
+      outcome,
+      blockNumber: 0,
+      logIndex: 0,
+    });
+
     const minPrice = marketsRow.minPrice;
     const maxPrice = marketsRow.maxPrice;
     const numTicks = marketsRow.numTicks;
@@ -32,7 +59,8 @@ export async function processOrderCreatedLog(augur: Augur, log: FormattedEventLo
     const fullPrecisionPrice = augur.utils.convertOnChainPriceToDisplayPrice(price, minPrice, tickSize);
     const orderTypeLabel = orderType === "0" ? "buy" : "sell";
     const displaySharesEscrowed = augur.utils.convertOnChainAmountToDisplayAmount(sharesEscrowed, tickSize).toString();
-    const displayTokensEscrowed = fixedPointToDecimal(moneyEscrowed, BN_WEI_PER_ETHER).toString();
+    const displayTokensEscrowedBN = fixedPointToDecimal(moneyEscrowed, BN_WEI_PER_ETHER);
+    const displayTokensEscrowed = displayTokensEscrowedBN.toString();
     const orderData: OrdersRow<string> = {
       marketId,
       blockNumber: log.blockNumber,
@@ -66,12 +94,37 @@ export async function processOrderCreatedLog(augur: Augur, log: FormattedEventLo
     await upsertOrder;
     await marketPendingOrphanCheck(db, orderData);
 
+    const nextFrozenFunds: FrozenFunds = getFrozenFundsAfterEventForOneOutcome({
+      frozenFundsBeforeEvent: prevProfitLoss,
+      event: {
+        orderCreatedEvent: true,
+        originalTokensEscrowed: displayTokensEscrowedBN,
+      },
+    });
+
+    const nextProfitLoss: ProfitLossTimeseriesRow<string> = Object.assign({}, prevProfitLoss, {
+      timestamp: getCurrentTime(),
+      price: prevProfitLoss.price.toString(),
+      position: prevProfitLoss.position.toString(),
+      quantityOpened: prevProfitLoss.quantityOpened.toString(),
+      profit: prevProfitLoss.profit.toString(),
+      realizedCost: prevProfitLoss.realizedCost.toString(),
+      frozenFunds: nextFrozenFunds.frozenFunds.toString(),
+      blockNumber: log.blockNumber,
+      logIndex: log.logIndex,
+      transactionHash: log.transactionHash,
+    });
+    await db.insert(nextProfitLoss).into("wcl_profit_loss_timeseries");
+
     augurEmitter.emit(SubscriptionEventNames.OrderCreated, Object.assign({}, log, orderData));
   };
 }
 
 export async function processOrderCreatedLogRemoval(augur: Augur, log: FormattedEventLog) {
   return async (db: Knex) => {
+    await db("wcl_profit_loss_timeseries")
+      .delete()
+      .where({ transactionHash: log.transactionHash });
     await db.from("orders").where("orderId", log.orderId).delete();
     augurEmitter.emit(SubscriptionEventNames.OrderCreated, log);
   };

--- a/src/seeds/test/wcl_profit_loss_timeseries.ts
+++ b/src/seeds/test/wcl_profit_loss_timeseries.ts
@@ -1,0 +1,25 @@
+import * as Knex from "knex";
+import { ProfitLossTimeseriesRow } from "../../server/getters/get-profit-loss";
+
+exports.seed = async (knex: Knex): Promise<any> => {
+  // Deletes ALL existing entries
+  return knex("wcl_profit_loss_timeseries").del().then(async (): Promise<any> => {
+    // Inserts seed entries
+    const seedData: Array<ProfitLossTimeseriesRow<string>> = [{
+      timestamp: 0,
+      account: "0x0000000000000000000000000000000000000b0b",
+      marketId: "0x0000000000000000000000000000000000000001",
+      outcome: 0,
+      transactionHash: "0x0000000000000000000000000000000000000000000000000000000000000A00",
+      price: "7",
+      position: "8",
+      quantityOpened: "-5",
+      profit: "12",
+      realizedCost: "32",
+      frozenFunds: "1.6",
+      blockNumber: 1400001,
+      logIndex: 0,
+    }];
+    return knex.batchInsert("wcl_profit_loss_timeseries", seedData, seedData.length);
+  });
+};

--- a/src/server/post-process-database-results.ts
+++ b/src/server/post-process-database-results.ts
@@ -124,6 +124,7 @@ const whitelist: TableWhitelist = {
     profit: true,
     frozenFunds: true,
     realizedCost: true,
+    quantityOpened: true,
   },
 };
 

--- a/test/unit/blockchain/log-processors/order-created.js
+++ b/test/unit/blockchain/log-processors/order-created.js
@@ -40,9 +40,29 @@ describe("blockchain/log-processors/order-created", () => {
     transactionHash: "0x0000000000000000000000000000000000000000000000000000000000000B00",
     logIndex: 0,
   };
-  test("OrderCreated log and removal", async () => {
+  test("OrderCreated log and removal with default wcl_profit_loss_timeseries", async () => {
     await db.transaction(async (trx) => {
       await(await processOrderCreatedLog(augur, log))(trx);
+      const latestProfitLoss = await trx
+        .first()
+        .from("wcl_profit_loss_timeseries")
+        .where({ account: "CREATOR_ADDRESS", marketId: "0x0000000000000000000000000000000000000001", outcome: 0, transactionHash: "0x0000000000000000000000000000000000000000000000000000000000000B00" })
+        .orderByRaw(`"blockNumber" DESC, "logIndex" DESC, "rowid" DESC`);
+      expect(latestProfitLoss).toEqual({
+        timestamp: 0,
+        account: "CREATOR_ADDRESS",
+        marketId: "0x0000000000000000000000000000000000000001",
+        outcome: 0,
+        transactionHash: "0x0000000000000000000000000000000000000000000000000000000000000B00",
+        price: new BigNumber(0),
+        position: new BigNumber(0),
+        quantityOpened: new BigNumber(0),
+        profit: new BigNumber(0),
+        realizedCost: new BigNumber(0),
+        frozenFunds: new BigNumber(2.25),
+        blockNumber: 1400100,
+        logIndex: 0,
+      });
       expect(await getState(trx, log)).toEqual([{
         orderId: "ORDER_ID",
         blockNumber: 1400100,
@@ -73,7 +93,53 @@ describe("blockchain/log-processors/order-created", () => {
         orderType: "buy",
       }]);
       await(await processOrderCreatedLogRemoval(augur, log))(trx);
+      const latestProfitLossRemoved = await trx
+        .first()
+        .from("wcl_profit_loss_timeseries")
+        .where({ account: "CREATOR_ADDRESS", marketId: "0x0000000000000000000000000000000000000001", outcome: 0, transactionHash: "0x0000000000000000000000000000000000000000000000000000000000000B00" })
+        .orderByRaw(`"blockNumber" DESC, "logIndex" DESC, "rowid" DESC`);
+      expect(latestProfitLossRemoved).toEqual(undefined);
       expect(await getState(trx, log)).toEqual([]);
+    });
+  });
+  test("OrderCreated with previously existing wcl_profit_loss_timeseries", async () => {
+    await db.transaction(async (trx) => {
+      await trx.insert({
+        timestamp: 0,
+        account: "CREATOR_ADDRESS",
+        marketId: "0x0000000000000000000000000000000000000001",
+        outcome: 0,
+        transactionHash: "0x0000000000000000000000000000000000000000000000000000000000001337",
+        price: "1",
+        position: "2.5",
+        quantityOpened: "3",
+        profit: "4",
+        realizedCost: "5",
+        frozenFunds: "1.42",
+        blockNumber: 13371,
+        logIndex: 6,
+      }).into("wcl_profit_loss_timeseries");
+      await(await processOrderCreatedLog(augur, log))(trx);
+      const latestProfitLoss = await trx
+        .first()
+        .from("wcl_profit_loss_timeseries")
+        .where({ account: "CREATOR_ADDRESS", marketId: "0x0000000000000000000000000000000000000001", outcome: 0, transactionHash: "0x0000000000000000000000000000000000000000000000000000000000000B00" })
+        .orderByRaw(`"blockNumber" DESC, "logIndex" DESC, "rowid" DESC`);
+      expect(latestProfitLoss).toEqual({
+        timestamp: 0,
+        account: "CREATOR_ADDRESS",
+        marketId: "0x0000000000000000000000000000000000000001",
+        outcome: 0,
+        transactionHash: "0x0000000000000000000000000000000000000000000000000000000000000B00",
+        price: new BigNumber(1),
+        position: new BigNumber(2.5),
+        quantityOpened: new BigNumber(3),
+        profit: new BigNumber(4),
+        realizedCost: new BigNumber(5),
+        frozenFunds: new BigNumber(3.67),
+        blockNumber: 1400100,
+        logIndex: 0,
+      });
     });
   });
 

--- a/test/unit/blockchain/log-processors/profit-loss/frozen-funds.ts
+++ b/test/unit/blockchain/log-processors/profit-loss/frozen-funds.ts
@@ -13,13 +13,15 @@ interface TestCase extends FrozenFundsParams {
   expectedFrozenFunds: FrozenFunds;
 }
 
-const testClaims: Array<TestCase> = [
+const testSimpleEvents: Array<TestCase> = [
   {
     name: "ClaimProceeds keeps frozen funds to zero",
     frozenFundsBeforeEvent: {
       frozenFunds: ZERO,
     },
-    event: "ClaimProceeds",
+    event: {
+      claimProceedsEvent: true,
+    },
     expectedFrozenFunds: {
       frozenFunds: ZERO,
     },
@@ -29,9 +31,37 @@ const testClaims: Array<TestCase> = [
     frozenFundsBeforeEvent: {
       frozenFunds: bn(29),
     },
-    event: "ClaimProceeds",
+    event: {
+      claimProceedsEvent: true,
+    },
     expectedFrozenFunds: {
       frozenFunds: ZERO,
+    },
+  },
+  {
+    name: "OrderCreated adds originalTokensEscrowed to frozen funds",
+    frozenFundsBeforeEvent: {
+      frozenFunds: bn(17),
+    },
+    event: {
+      orderCreatedEvent: true,
+      originalTokensEscrowed: bn(42),
+    },
+    expectedFrozenFunds: {
+      frozenFunds: bn(59),
+    },
+  },
+  {
+    name: "OrderCanceled substracts tokensEscrowed to frozen funds",
+    frozenFundsBeforeEvent: {
+      frozenFunds: bn(0.1387),
+    },
+    event: {
+      orderCanceledEvent: true,
+      tokensEscrowed: bn(37.387),
+    },
+    expectedFrozenFunds: {
+      frozenFunds: bn(0.1387 - 37.387),
     },
   },
 ];
@@ -43,6 +73,7 @@ const testTrades: Array<TestCase> = [
       frozenFunds: ZERO,
     },
     event: {
+      tradeEvent: true,
       minPrice: bn(0),
       maxPrice: bn(1),
       price: bn(0.65),
@@ -51,6 +82,7 @@ const testTrades: Array<TestCase> = [
       numFillerTokens: bn(0),
       numFillerShares: bn(0),
       longOrShort: "short",
+      isSelfFilled: false,
       creatorOrFiller: "creator",
       realizedProfitDelta: bn(0),
     },
@@ -65,6 +97,7 @@ const testTrades: Array<TestCase> = [
       frozenFunds: bn(3.5),
     },
     event: {
+      tradeEvent: true,
       minPrice: bn(0),
       maxPrice: bn(1),
       price: bn(0.58),
@@ -73,6 +106,7 @@ const testTrades: Array<TestCase> = [
       numFillerTokens: bn(0),
       numFillerShares: bn(0),
       longOrShort: "long",
+      isSelfFilled: false,
       creatorOrFiller: "creator",
       realizedProfitDelta: bn(0.21),
     },
@@ -87,6 +121,7 @@ const testTrades: Array<TestCase> = [
       frozenFunds: bn(2.45),
     },
     event: {
+      tradeEvent: true,
       minPrice: bn(0),
       maxPrice: bn(1),
       price: bn(0.62),
@@ -95,6 +130,7 @@ const testTrades: Array<TestCase> = [
       numFillerTokens: bn(0),
       numFillerShares: bn(0),
       longOrShort: "short",
+      isSelfFilled: false,
       creatorOrFiller: "creator",
       realizedProfitDelta: bn(0),
     },
@@ -108,6 +144,7 @@ const testTrades: Array<TestCase> = [
       frozenFunds: bn(7.39),
     },
     event: {
+      tradeEvent: true,
       minPrice: bn(0),
       maxPrice: bn(1),
       price: bn(0.5),
@@ -116,6 +153,7 @@ const testTrades: Array<TestCase> = [
       numFillerTokens: bn(0),
       numFillerShares: bn(0),
       longOrShort: "long",
+      isSelfFilled: false,
       creatorOrFiller: "creator",
       realizedProfitDelta: bn(1.515 - 0.21),
     },
@@ -130,6 +168,7 @@ const testTrades: Array<TestCase> = [
       frozenFunds: bn(3.695),
     },
     event: {
+      tradeEvent: true,
       minPrice: bn(0),
       maxPrice: bn(1),
       price: bn(0.15),
@@ -138,6 +177,7 @@ const testTrades: Array<TestCase> = [
       numFillerTokens: bn(0),
       numFillerShares: bn(0),
       longOrShort: "long",
+      isSelfFilled: false,
       creatorOrFiller: "creator",
       realizedProfitDelta: bn(4.8785 - 1.515),
     },
@@ -151,6 +191,7 @@ const testTrades: Array<TestCase> = [
       frozenFunds: ZERO,
     },
     event: {
+      tradeEvent: true,
       minPrice: bn(0),
       maxPrice: bn(1),
       price: bn(0.4),
@@ -159,6 +200,7 @@ const testTrades: Array<TestCase> = [
       numFillerTokens: bn(0),
       numFillerShares: bn(0),
       longOrShort: "long",
+      isSelfFilled: false,
       creatorOrFiller: "creator",
       realizedProfitDelta: bn(0),
     },
@@ -172,6 +214,7 @@ const testTrades: Array<TestCase> = [
       frozenFunds: ZERO,
     },
     event: {
+      tradeEvent: true,
       minPrice: bn(0),
       maxPrice: bn(1),
       price: bn(0.2),
@@ -180,6 +223,7 @@ const testTrades: Array<TestCase> = [
       numFillerTokens: bn(0),
       numFillerShares: bn(0),
       longOrShort: "short",
+      isSelfFilled: false,
       creatorOrFiller: "creator",
       realizedProfitDelta: bn(0),
     },
@@ -193,6 +237,7 @@ const testTrades: Array<TestCase> = [
       frozenFunds: ZERO,
     },
     event: {
+      tradeEvent: true,
       minPrice: bn(0),
       maxPrice: bn(1),
       price: bn(0.3),
@@ -201,6 +246,7 @@ const testTrades: Array<TestCase> = [
       numFillerTokens: bn(0),
       numFillerShares: bn(0),
       longOrShort: "long",
+      isSelfFilled: false,
       creatorOrFiller: "creator",
       realizedProfitDelta: bn(0),
     },
@@ -215,6 +261,7 @@ const testTrades: Array<TestCase> = [
       frozenFunds: bn(0.4),
     },
     event: {
+      tradeEvent: true,
       minPrice: bn(0),
       maxPrice: bn(1),
       price: bn(0.7),
@@ -223,6 +270,7 @@ const testTrades: Array<TestCase> = [
       numFillerTokens: bn(0),
       numFillerShares: bn(0),
       longOrShort: "short",
+      isSelfFilled: false,
       creatorOrFiller: "creator",
       realizedProfitDelta: bn(0.3),
     },
@@ -236,6 +284,7 @@ const testTrades: Array<TestCase> = [
       frozenFunds: ZERO,
     },
     event: {
+      tradeEvent: true,
       minPrice: bn(0),
       maxPrice: bn(1),
       price: bn(0.4),
@@ -244,6 +293,7 @@ const testTrades: Array<TestCase> = [
       numFillerTokens: bn(0),
       numFillerShares: bn(0),
       longOrShort: "short",
+      isSelfFilled: false,
       creatorOrFiller: "creator",
       realizedProfitDelta: bn(0),
     },
@@ -257,6 +307,7 @@ const testTrades: Array<TestCase> = [
       frozenFunds: ZERO,
     },
     event: {
+      tradeEvent: true,
       minPrice: bn(0),
       maxPrice: bn(1),
       price: bn(0.35),
@@ -265,6 +316,7 @@ const testTrades: Array<TestCase> = [
       numFillerTokens: bn(0),
       numFillerShares: bn(0),
       longOrShort: "short",
+      isSelfFilled: false,
       creatorOrFiller: "creator",
       realizedProfitDelta: bn(0),
     },
@@ -278,14 +330,16 @@ const testTrades: Array<TestCase> = [
       frozenFunds: ZERO,
     },
     event: {
+      tradeEvent: true,
       minPrice: bn(0),
       maxPrice: bn(1),
       price: bn(0.3),
       numCreatorTokens: bn(3.5),
       numCreatorShares: bn(5),
-      numFillerTokens: bn(3),
+      numFillerTokens: bn(0),
       numFillerShares: bn(0),
       longOrShort: "short",
+      isSelfFilled: false,
       creatorOrFiller: "creator",
       realizedProfitDelta: bn(0),
     },
@@ -299,6 +353,7 @@ const testTrades: Array<TestCase> = [
       frozenFunds: bn(2),
     },
     event: {
+      tradeEvent: true,
       minPrice: bn(0),
       maxPrice: bn(1),
       price: bn(0.1),
@@ -307,6 +362,7 @@ const testTrades: Array<TestCase> = [
       numFillerTokens: bn(0),
       numFillerShares: bn(0),
       longOrShort: "long",
+      isSelfFilled: false,
       creatorOrFiller: "creator",
       realizedProfitDelta: bn(1.6),
     },
@@ -320,6 +376,7 @@ const testTrades: Array<TestCase> = [
       frozenFunds: bn(0),
     },
     event: {
+      tradeEvent: true,
       minPrice: bn(0),
       maxPrice: bn(1),
       price: bn(0.15),
@@ -328,6 +385,7 @@ const testTrades: Array<TestCase> = [
       numFillerTokens: bn(0),
       numFillerShares: bn(0),
       longOrShort: "long",
+      isSelfFilled: false,
       creatorOrFiller: "creator",
       realizedProfitDelta: bn(0),
     },
@@ -341,6 +399,7 @@ const testTrades: Array<TestCase> = [
       frozenFunds: bn(0),
     },
     event: {
+      tradeEvent: true,
       minPrice: bn(0),
       maxPrice: bn(1),
       price: bn(0.1),
@@ -349,6 +408,7 @@ const testTrades: Array<TestCase> = [
       numFillerTokens: bn(0),
       numFillerShares: bn(0),
       longOrShort: "long",
+      isSelfFilled: false,
       creatorOrFiller: "creator",
       realizedProfitDelta: bn(0),
     },
@@ -362,6 +422,7 @@ const testTrades: Array<TestCase> = [
       frozenFunds: bn(0),
     },
     event: {
+      tradeEvent: true,
       minPrice: bn(0),
       maxPrice: bn(1),
       price: bn(0.6),
@@ -370,6 +431,7 @@ const testTrades: Array<TestCase> = [
       numFillerTokens: bn(0),
       numFillerShares: bn(0),
       longOrShort: "long",
+      isSelfFilled: false,
       creatorOrFiller: "creator",
       realizedProfitDelta: bn(0),
     },
@@ -383,6 +445,7 @@ const testTrades: Array<TestCase> = [
       frozenFunds: bn(2.5),
     },
     event: {
+      tradeEvent: true,
       minPrice: bn(0),
       maxPrice: bn(1),
       price: bn(0.2),
@@ -391,6 +454,7 @@ const testTrades: Array<TestCase> = [
       numFillerTokens: bn(0),
       numFillerShares: bn(0),
       longOrShort: "short",
+      isSelfFilled: false,
       creatorOrFiller: "creator",
       realizedProfitDelta: bn(1.3),
     },
@@ -405,6 +469,7 @@ const testTrades: Array<TestCase> = [
       frozenFunds: bn(-2),
     },
     event: {
+      tradeEvent: true,
       minPrice: bn(0),
       maxPrice: bn(1),
       price: bn(0.8),
@@ -413,6 +478,7 @@ const testTrades: Array<TestCase> = [
       numFillerTokens: bn(0),
       numFillerShares: bn(0),
       longOrShort: "short",
+      isSelfFilled: false,
       creatorOrFiller: "creator",
       realizedProfitDelta: bn(0.6),
     },
@@ -426,6 +492,7 @@ const testTrades: Array<TestCase> = [
       frozenFunds: bn(1.5),
     },
     event: {
+      tradeEvent: true,
       minPrice: bn(0),
       maxPrice: bn(1),
       price: bn(0.1),
@@ -434,6 +501,7 @@ const testTrades: Array<TestCase> = [
       numFillerTokens: bn(0),
       numFillerShares: bn(0),
       longOrShort: "short",
+      isSelfFilled: false,
       creatorOrFiller: "creator",
       realizedProfitDelta: bn(-0.5),
     },
@@ -447,6 +515,7 @@ const testTrades: Array<TestCase> = [
       frozenFunds: bn(0),
     },
     event: {
+      tradeEvent: true,
       minPrice: bn(50),
       maxPrice: bn(250),
       price: bn(200),
@@ -455,6 +524,7 @@ const testTrades: Array<TestCase> = [
       numFillerTokens: bn(0),
       numFillerShares: bn(0),
       longOrShort: "long",
+      isSelfFilled: false,
       creatorOrFiller: "creator",
       realizedProfitDelta: bn(0),
     },
@@ -468,6 +538,7 @@ const testTrades: Array<TestCase> = [
       frozenFunds: bn(300),
     },
     event: {
+      tradeEvent: true,
       minPrice: bn(50),
       maxPrice: bn(250),
       price: bn(180),
@@ -476,6 +547,7 @@ const testTrades: Array<TestCase> = [
       numFillerTokens: bn(0),
       numFillerShares: bn(0),
       longOrShort: "long",
+      isSelfFilled: false,
       creatorOrFiller: "creator",
       realizedProfitDelta: bn(0),
     },
@@ -490,6 +562,7 @@ const testTrades: Array<TestCase> = [
       frozenFunds: bn(690),
     },
     event: {
+      tradeEvent: true,
       minPrice: bn(50),
       maxPrice: bn(250),
       price: bn(202),
@@ -498,6 +571,7 @@ const testTrades: Array<TestCase> = [
       numFillerTokens: bn(0),
       numFillerShares: bn(0),
       longOrShort: "short",
+      isSelfFilled: false,
       creatorOrFiller: "creator",
       realizedProfitDelta: bn(56),
     },
@@ -511,6 +585,7 @@ const testTrades: Array<TestCase> = [
       frozenFunds: bn(138),
     },
     event: {
+      tradeEvent: true,
       minPrice: bn(50),
       maxPrice: bn(250),
       price: bn(205),
@@ -519,6 +594,7 @@ const testTrades: Array<TestCase> = [
       numFillerTokens: bn(0),
       numFillerShares: bn(0),
       longOrShort: "short",
+      isSelfFilled: false,
       creatorOrFiller: "creator",
       realizedProfitDelta: bn(73 - 56),
     },
@@ -534,6 +610,7 @@ const testTrades: Array<TestCase> = [
       frozenFunds: bn(450),
     },
     event: {
+      tradeEvent: true,
       minPrice: bn(50),
       maxPrice: bn(250),
       price: bn(150),
@@ -542,6 +619,7 @@ const testTrades: Array<TestCase> = [
       numFillerTokens: bn(0),
       numFillerShares: bn(0),
       longOrShort: "long",
+      isSelfFilled: false,
       creatorOrFiller: "creator",
       realizedProfitDelta: bn(458 - 73),
     },
@@ -549,10 +627,47 @@ const testTrades: Array<TestCase> = [
       frozenFunds: bn(135),
     },
   },
+  {
+    name: "self-filled #1",
+    frozenFundsBeforeEvent: {
+      frozenFunds: bn(17.34),
+    },
+    event: {
+      tradeEvent: true,
+      minPrice: bn(-50),
+      maxPrice: bn(150),
+      price: bn(100),
+      numCreatorTokens: bn(983.5),
+      numCreatorShares: bn(7),
+      // total value of creator contribution = 983.5 + 350 = 1333.5
+      numFillerTokens: bn(1108.5),
+      numFillerShares: bn(1.5),
+      // total value of filler contribution = 1108.5 + 225 = 1333.5
+      longOrShort: "long",
+      isSelfFilled: true,
+      creatorOrFiller: "creator",
+      realizedProfitDelta: bn(34),
+    },
+    expectedFrozenFunds: {
+      frozenFunds: bn((() => {
+        const startFF = bn(17.34);
+        const mySharesSent = bn(7);
+        const priceReceivedForMySharesSent = bn(50);
+        const myTokensReceived = mySharesSent.times(priceReceivedForMySharesSent);
+        const theirSharesSent = bn(1.5);
+        const theirPriceReceivedForTheirSharesSent = bn(150);
+        const theirTokensReceived = theirSharesSent.times(theirPriceReceivedForTheirSharesSent);
+        const portionOfMyTokensSentUsedToCreateCompleteSets = bn(983.5).minus(theirTokensReceived);
+        const myTokensSent = bn(983.5);
+        const realizedProfitDelta = bn(34);
+        return startFF.plus(myTokensSent).minus(myTokensReceived).plus(realizedProfitDelta).minus(portionOfMyTokensSentUsedToCreateCompleteSets).toNumber();
+      })()),
+    },
+  },
 ];
 
 const testData: Array<TestCase> = [
-  ...testClaims,
+  ...testSimpleEvents,
   ...testTrades,
 
   // Autogenerate test cases to ensure algorithm correctly handles
@@ -572,13 +687,29 @@ const testData: Array<TestCase> = [
     tmp = trade.numCreatorTokens;
     trade.numCreatorTokens = trade.numFillerTokens;
     trade.numFillerTokens = tmp;
+
+    // The self-filled trades declared in testTrades have `myTokensSent` added to
+    // FF which is then subtracted below. We need to reverse the subtraction if
+    // this auto-generated test case is filler. The root cause here is that the
+    // auto-generated test cases only work if frozenFunds algorithm is symmetric
+    // for filler/creator, but as of recent update is no longer symmetric, but still
+    // worth having the auto-generated test cases because they hit more code paths.
+    if (trade.isSelfFilled && trade.creatorOrFiller === "filler") {
+      tc2.expectedFrozenFunds.frozenFunds = tc2.expectedFrozenFunds.frozenFunds.plus(trade.numCreatorTokens);
+    }
     return tc2;
   }),
 ];
 
-testData.forEach((tc) => {
+testData.forEach((tc: TestCase) => {
   test(tc.name, () => {
+    let expectedFF = tc.expectedFrozenFunds.frozenFunds;
+    if ("tradeEvent" in tc.event) {
+      // creator tokens aren't added to FF because they were
+      // previously added to FF when order created log was processed.
+      expectedFF = expectedFF.minus(tc.event.numCreatorTokens);
+    }
     expect(getFrozenFundsAfterEventForOneOutcome(tc)
-      .frozenFunds).toEqual(tc.expectedFrozenFunds.frozenFunds);
+      .frozenFunds).toEqual(expectedFF);
   });
 });


### PR DESCRIPTION
Frozen funds now includes tokens escrowed for open orders.

Frozen funds now handles self-filled trades: if a trade is self-filled (ie. user
traded with themselves), then the OrderCreated log looks the same as if the
trade was not self-filled, but the contracts silently skip creating complete
sets, instead returning tokens to the user. So augur-node deducts these tokens
from frozen funds to handle this on-chain exception.

AugurProject/augur#1869 AugurProject/augur#1852