### PR TITLE
tradeGroupId should be a string

### DIFF
--- a/src/migrations/20190205102050_rm_complete_sets_trade_group_id.ts
+++ b/src/migrations/20190205102050_rm_complete_sets_trade_group_id.ts
@@ -8,6 +8,6 @@ exports.up = async (knex: Knex): Promise<any> => {
 
 exports.down = async (knex: Knex): Promise<any> => {
   return knex.schema.table("completeSets", (table: Knex.CreateTableBuilder): void => {
-    table.integer("tradeGroupId");
+    table.string("tradeGroupId");
   });
 };


### PR DESCRIPTION
Getting errors in the migration script in augur app.

![image](https://user-images.githubusercontent.com/3970376/57805931-a8bc8a80-7723-11e9-8c11-f994c1c2fe55.png)

it is only there to match up orders not calculations are performed on this field. tradeGroupId is a UUID