### PR TITLE
Disable 20190205102050_rm_complete_sets_trade_group_id.ts

### DIFF
--- a/src/migrations/20190205102050_rm_complete_sets_trade_group_id.ts
+++ b/src/migrations/20190205102050_rm_complete_sets_trade_group_id.ts
@@ -1,13 +1,9 @@
 import * as Knex from "knex";
 
 exports.up = async (knex: Knex): Promise<any> => {
-  return knex.schema.table("completeSets", (table: Knex.CreateTableBuilder): void => {
-    table.dropColumns("tradeGroupId");
-  });
+  // INTENTIONAL no-op, see commit "Disable 20190205102050_rm_complete_sets_trade_group_id.ts"
 };
 
 exports.down = async (knex: Knex): Promise<any> => {
-  return knex.schema.table("completeSets", (table: Knex.CreateTableBuilder): void => {
-    table.integer("tradeGroupId");
-  });
+  // INTENTIONAL no-op, see commit "Disable 20190205102050_rm_complete_sets_trade_group_id.ts"
 };

--- a/test/unit/blockchain/log-processors/completesets.js
+++ b/test/unit/blockchain/log-processors/completesets.js
@@ -45,6 +45,7 @@ describe("blockchain/log-processors/completesets", () => {
         marketId: "0x0000000000000000000000000000000000000002",
         numCompleteSets: new BigNumber("2", 10),
         numPurchasedOrSold: "2",
+        tradeGroupId: null, // DB completeSets.numCompleteSets is a nullable deprecated column that we can't remove because the dropColumn migration fails, see commit "Disable 20190205102050_rm_complete_sets_trade_group_id.ts"
         transactionHash: "0x00000000000000000000000000000000deadbeef",
         universe: "0x0000000000000000000000000000000000000001",
       }]);


### PR DESCRIPTION
This migration dropped column completeSets.tradeGroupId

This migration always fails since commit cd2ceba73 which added
`numCompleteSets: true` to post-process-database-results. It always fails
because sqlite doesn't support drop column natively and Knex implements this
internally by using a temp table; that temp table is affected by
post-process-database-results because the completeSets.numCompleteSets column
is converted to BigNumber when Knex reads it and then that BigNumber fails to
be written into the temp table.

The fix is to make the migration a no-op without actually deleting it.
This allows clients who already ran the migration to still find the migration
file (and Knex checks for this), but clients who haven't yet run the migration
will succeed because it's a no-op.