### PR TITLE
Liquidity filter cleanup

### DIFF
--- a/src/migrations/20190620173723_rebuild_liquidity_metrics.ts
+++ b/src/migrations/20190620173723_rebuild_liquidity_metrics.ts
@@ -1,0 +1,16 @@
+import * as Knex from "knex";
+import { updateLiquidityMetricsForMarketAndOutcomes } from "../utils/liquidity";
+
+exports.up = async (knex: Knex): Promise<any> => {
+  try {
+    for (const { marketId } of await knex.select("marketId").from("markets")) {
+      await updateLiquidityMetricsForMarketAndOutcomes(knex, marketId);
+    }
+  } catch {
+    console.info("**************************************************************************************************\n***** you can safely ignore these SQLITE errors which may occur normally during DB migration *****\n**************************************************************************************************");
+  }
+};
+
+exports.down = async (knex: Knex): Promise<any> => {
+  return Promise.resolve();
+};

--- a/src/server/getters/get-categories.ts
+++ b/src/server/getters/get-categories.ts
@@ -1,28 +1,29 @@
-import * as t from "io-ts";
-import * as Knex from "knex";
-import * as _ from "lodash";
 import Augur from "augur.js";
 import BigNumber from "bignumber.js";
-import { CategoriesRow, UICategory, TagAggregation, ReportingState } from "../../types";
+import * as t from "io-ts";
+import * as Knex from "knex";
+import { ZERO } from "../../constants";
+import { Address, ReportingState, TagAggregation, UICategory } from "../../types";
+import { getMarkets, GetMarketsParams } from "./get-markets";
+import { MAX_SPREAD_PERCENT } from "../../utils/liquidity";
 
 export const CategoriesParams = t.type({
   universe: t.string,
 });
 
 interface MarketsTagRow {
+  marketId: string;
   category: string;
   openInterest: BigNumber;
+  liquidityTokens: BigNumber;
   reportingState: ReportingState;
   tag1: string;
   tag2: string;
 }
 
-export async function getCategoriesRows(db: Knex, universe: string): Promise<Array<CategoriesRow<BigNumber>>> {
-  return db.select(["category", "nonFinalizedOpenInterest", "openInterest", "universe"]).from("categories").where({ universe });
-}
-
-export async function getMarketsTagRows(db: Knex, universe: string): Promise<Array<MarketsTagRow>> {
+export async function getMarketsTagRows(db: Knex, universe: string, spreadPercent: number): Promise<Array<MarketsTagRow>> {
   return db.select([
+    "markets.marketId as marketId",
     "markets.category as category",
     "markets.openInterest as openInterest",
     "markets.tag1 as tag1",
@@ -30,10 +31,31 @@ export async function getMarketsTagRows(db: Knex, universe: string): Promise<Arr
     "market_state.reportingState as reportingState",
   ]).from("markets")
     .leftJoin("market_state", "markets.marketStateId", "market_state.marketStateId")
+    .innerJoin("markets_liquidity", function() {
+      this.on("markets.marketId", "markets_liquidity.marketId")
+        .andOn("markets_liquidity.spreadPercent", db.raw("?", spreadPercent));
+    }).select("liquidityTokens")
     .where({ universe });
 }
 
-function buildUICategories(categoriesRows: Array<CategoriesRow<BigNumber>>, marketsTagRows: Array<MarketsTagRow>): Array<UICategory<string>> {
+function uiCategoryBigNumberToString(uiCat: UICategory<BigNumber>): UICategory<string> {
+  return {
+    ...uiCat,
+    nonFinalizedOpenInterest: uiCat.nonFinalizedOpenInterest.toString(),
+    openInterest: uiCat.openInterest.toString(),
+    liquidityTokens: uiCat.liquidityTokens.toString(),
+    tags: uiCat.tags.map((ta) => {
+      return {
+        ...ta,
+        nonFinalizedOpenInterest: ta.nonFinalizedOpenInterest.toString(),
+        openInterest: ta.openInterest.toString(),
+        liquidityTokens: ta.liquidityTokens.toString(),
+      };
+    }),
+  };
+}
+
+function buildUICategories(marketsTagRows: Array<MarketsTagRow>, marketIdWhitelist: Array<Address>): Array<UICategory<BigNumber>> {
   function upsertTagAggregation(r: MarketsTagRow, tagAggregationByTagName: Map<string, TagAggregation<BigNumber>>, tagProp: "tag1" | "tag2"): void {
     if (!r[tagProp]) {
       return;
@@ -41,8 +63,9 @@ function buildUICategories(categoriesRows: Array<CategoriesRow<BigNumber>>, mark
     let tagAggregation: TagAggregation<BigNumber> | undefined = tagAggregationByTagName.get(r[tagProp]);
     if (tagAggregation === undefined) {
       tagAggregation = {
-        nonFinalizedOpenInterest: new BigNumber("0", 10),
-        openInterest: new BigNumber("0", 10),
+        nonFinalizedOpenInterest: ZERO,
+        openInterest: ZERO,
+        liquidityTokens: ZERO,
         tagName: r[tagProp],
         numberOfMarketsWithThisTag: 0,
       };
@@ -52,12 +75,18 @@ function buildUICategories(categoriesRows: Array<CategoriesRow<BigNumber>>, mark
       tagAggregation.nonFinalizedOpenInterest = tagAggregation.nonFinalizedOpenInterest.plus(r.openInterest);
     }
     tagAggregation.openInterest = tagAggregation.openInterest.plus(r.openInterest);
+    tagAggregation.liquidityTokens = tagAggregation.liquidityTokens.plus(r.liquidityTokens);
     tagAggregation.numberOfMarketsWithThisTag += 1;
   }
 
+  const marketIdWhitelistSet = new Set(marketIdWhitelist);
+
   const tagAggregationByTagNameByCategoryName: Map<string, Map<string, TagAggregation<BigNumber>>> = new Map(); // there'll be a parent-child relationship where TagAggregation is the child and category is the parent. Tags aren't aggregated across categories. If two markets share a tag, but have different categories, that tag will build into two different TagAggregations, one for each category.
 
-  marketsTagRows.forEach((r: MarketsTagRow) => {
+  const uiCategoryByCategoryName: Map<string, UICategory<BigNumber>> = new Map();
+
+  marketsTagRows.filter((r) => marketIdWhitelistSet.has(r.marketId)).forEach((r: MarketsTagRow) => {
+    // 1. build TagAggregations scoped by category; they will each later be assigned as uiCategory.tags
     let tagAggregationByTagName: Map<string, TagAggregation<BigNumber>> | undefined = tagAggregationByTagNameByCategoryName.get(r.category);
     if (tagAggregationByTagName === undefined) {
       tagAggregationByTagName = new Map();
@@ -65,40 +94,52 @@ function buildUICategories(categoriesRows: Array<CategoriesRow<BigNumber>>, mark
     }
     upsertTagAggregation(r, tagAggregationByTagName, "tag1");
     upsertTagAggregation(r, tagAggregationByTagName, "tag2");
+
+    // 2. build UICategories to return, but they don't yet have tags assigned
+    let uiCat = uiCategoryByCategoryName.get(r.category);
+    if (uiCat === undefined) {
+      uiCat = {
+        categoryName: r.category,
+        tags: [], // will be assigned later
+        nonFinalizedOpenInterest: ZERO,
+        openInterest: ZERO,
+        liquidityTokens: ZERO,
+      };
+      uiCategoryByCategoryName.set(r.category, uiCat);
+    }
+
+    if (r.reportingState !== ReportingState.FINALIZED) {
+      uiCat.nonFinalizedOpenInterest = uiCat.nonFinalizedOpenInterest.plus(r.openInterest);
+    }
+    uiCat.openInterest = uiCat.openInterest.plus(r.openInterest);
+    uiCat.liquidityTokens = uiCat.liquidityTokens.plus(r.liquidityTokens);
   });
 
-  return categoriesRows.map((r: CategoriesRow<BigNumber>) => {
-    let tags: Array<TagAggregation<string>> = [];
-    const tagAggregationByTagName = tagAggregationByTagNameByCategoryName.get(r.category);
-    if (tagAggregationByTagName !== undefined) {
-      tags = Array.from(tagAggregationByTagName.values()).map((taBigNumber: TagAggregation<BigNumber>) => {
-        // convert from TagAggregation<BigNumber> to TagAggregation<string>, because
-        // BigNumber is used for arithmetic when building the TagAggregation, but the
-        // UI receives numbers as strings to avoid precision loss during serialization
-        return {
-          nonFinalizedOpenInterest: taBigNumber.nonFinalizedOpenInterest.toString(),
-          openInterest: taBigNumber.openInterest.toString(),
-          tagName: taBigNumber.tagName,
-          numberOfMarketsWithThisTag: taBigNumber.numberOfMarketsWithThisTag,
-        };
-      });
+  // 3. assign tags to categories now that both are fully built
+  tagAggregationByTagNameByCategoryName.forEach((tagAggregationByTagName, categoryName) => {
+    const uiCat = uiCategoryByCategoryName.get(categoryName);
+    if (uiCat !== undefined) {
+      uiCat.tags = Array.from(tagAggregationByTagName.values());
     }
-    return {
-      nonFinalizedOpenInterest: r.nonFinalizedOpenInterest.toString(),
-      openInterest: r.openInterest.toString(),
-      categoryName: r.category,
-      tags,
-    };
   });
+
+  const uiCategories = Array.from(uiCategoryByCategoryName.values());
+  return uiCategories;
 }
 
-export async function getCategories(db: Knex, augur: Augur, params: t.TypeOf<typeof CategoriesParams>): Promise<Array<UICategory<string>>> {
+export async function getCategories(db: Knex, augur: Augur, params: t.TypeOf<typeof GetMarketsParams>): Promise<Array<UICategory<string>>> {
   const universeInfo = await db.first(["universe"]).from("universes").where({ universe: params.universe });
   if (universeInfo === undefined) throw new Error(`Universe ${params.universe} does not exist`);
 
-  const p1: Promise<Array<CategoriesRow<BigNumber>>> = getCategoriesRows(db, params.universe);
-  const p2: Promise<Array<MarketsTagRow>> = getMarketsTagRows(db, params.universe);
-  const cs: Array<CategoriesRow<BigNumber>> = await p1;
-  const ts: Array<MarketsTagRow> = await p2;
-  return buildUICategories(cs, ts);
+  const p1: Promise<Array<MarketsTagRow>> = getMarketsTagRows(db, params.universe, params.liquiditySortSpreadPercent || MAX_SPREAD_PERCENT);
+  const p2: Promise<Array<Address>> = getMarkets(db, augur, {
+    ...params,
+    limit: undefined,
+    offset: undefined,
+  });
+  const ts: Array<MarketsTagRow> = await p1;
+  const mids: Array<Address> = await p2;
+
+  const uiCategories = buildUICategories(ts, mids).map(uiCategoryBigNumberToString);
+  return uiCategories;
 }

--- a/src/server/getters/get-markets.ts
+++ b/src/server/getters/get-markets.ts
@@ -25,7 +25,7 @@ export const GetMarketsParams = t.intersection([
 ]);
 
 // Returning marketIds should likely be more generalized, since it is a single line change for most getters (awaiting reporting, by user, etc)
-export async function getMarkets(db: Knex, augur: {}, params: t.TypeOf<typeof GetMarketsParams>) {
+export async function getMarkets(db: Knex, augur: {}, params: t.TypeOf<typeof GetMarketsParams>): Promise<Array<Address>> {
   const columns = ["markets.marketId", "marketStateBlock.timestamp as reportingStateUpdatedOn"];
   const query = getMarketsWithReportingState(db, columns);
   query.join("blocks as marketStateBlock", "marketStateBlock.blockNumber", "market_state.blockNumber");

--- a/src/types.ts
+++ b/src/types.ts
@@ -470,6 +470,7 @@ export type UIMarketsInfo<BigNumberType> = Array<UIMarketInfo<BigNumberType>|nul
 export interface OpenInterestAggregation<BigNumberType> {
   nonFinalizedOpenInterest: BigNumberType; // sum of open interest for non-finalized markets in this aggregation (ie. markets with ReportingState != FINALIZED)
   openInterest: BigNumberType; // sum of open interest for all markets in this aggregation
+  liquidityTokens: BigNumberType; // sum of markets_liquidity.liquidityTokens for all markets in this aggregation for a given markets_liquidity.spreadPercent because a market has one liquidityTokens per spreadPercent
 }
 
 // TagAggregation is an aggregation of tag statistics/data for a set of

--- a/src/utils/dimension-quantity.ts
+++ b/src/utils/dimension-quantity.ts
@@ -4,6 +4,10 @@ const ZERO = new BigNumber(0);
 const ONE = new BigNumber(1);
 const TWO = new BigNumber(2);
 
+// TODO big v2 upgrade/refactor where some of the domain-specific types expressed in finmath become dimension-quantity types, eg. instead of `interface SharePrice { sharePrice: Price; }` we can have `class SharePrice extends Quantity<Shares>` where its dimension vector = `{ domain: 'sharePrice', ...PriceUnitDimension }` such that the "sharePrice" becomes part of its dimension. Not sure if this is a good idea/pattern or a terrible idea, eg. how do you add a sharePrice and a tradePrice if they effectively have different dimensions? Then again maybe you should only be using dimension-quantity's new `domain` dimension if "SharePrice vs TradePrice" are as different as "SharePrice vs Percent" --> this seems to hold, eg. you'd never ever want to add a SharePrice and TradePrice, nor a SharePriceOnChain (eg. domain='sharePriceOnChain' ) and a SharePrice. --> but at what point do you say "this SharePrice is now a TradePrice because I added some stuff to it", how does conversion work? --> conversion should probably be built into the types themselves, sharePrice.toTradePrice(args)?
+
+// TODO to support GWei * 10^9 = Tokens include `scalar` in dimension vector... or maybe separate from dimension vector, since it's not part of the unit, it's a baked-in coefficient. So if you tried to add GWei and Tokens, the underlying dimension vectors would both be in tokens, but the GWei has a coefficient of 10*^-9 that needs to be normalized into Tokens scale before they can be added.
+
 // TODO toString() method "20 tokens", "20 tokens/share", "20 tokens^2*shares^-3"
 // TODO ETH/attoETH/erc20
 // TODO support derivation for non-unit quantity types, similar to safe-units. Eg. `export const Price = Tokens.dividedBy(Shares)`
@@ -15,6 +19,7 @@ const TWO = new BigNumber(2);
 // and could be extended to include Ether, but unfortunately is
 // impractical due to extremely long compile times (minutes).
 
+// TODO add "gas" and make Gas, GasPrice and use these in gas.ts
 type Dimension = "tokens" | "shares";
 const Dimensions: Array<Dimension> = ["tokens", "shares"];
 
@@ -224,6 +229,8 @@ class UnverifiedQuantity extends Quantity<UnverifiedQuantity> {
 // ************************************************************************
 // **** specific units below here; a lot of this could be generated code
 
+// TODO drop helper functions like scalar/percent/token and instead allow any constructor to take number or BigNumber
+
 export function scalar(magnitude: number | BigNumber): Scalar {
   if (typeof magnitude === "number") {
     return new Scalar(new BigNumber(magnitude, 10));
@@ -302,6 +309,7 @@ export function price(magnitude: number | BigNumber): Price {
   }
   return new Price(magnitude);
 }
+// TODO Price should be called a `TokenPrice` because it's Token/Shares. GasPrice is Gas/Shares. Update gas.ts to use these
 const PriceUnitDimension: DimensionVector = Object.freeze({
   tokens: 1,
   shares: -1,

--- a/src/utils/liquidity.ts
+++ b/src/utils/liquidity.ts
@@ -372,7 +372,7 @@ const LIQUIDITY_SPREAD_PERCENTS: Array<Percent> = [
   percent(MAX_SPREAD_PERCENT),
 ];
 
-const SELL_INCREMENT_COST_DEFAULT: Tokens = tokens(0.05);
+const SELL_INCREMENT_COST_DEFAULT: Tokens = tokens(0.02);
 let SELL_INCREMENT_COST: Tokens = SELL_INCREMENT_COST_DEFAULT;
 export function unsafeSetSELL_INCREMENT_COST(t: BigNumber): void {
   SELL_INCREMENT_COST = new Tokens(t);

--- a/test/unit/server/getters/get-categories.js
+++ b/test/unit/server/getters/get-categories.js
@@ -1,5 +1,6 @@
 const { setupTestDb, seedDb } = require("test.database");
 const { dispatchJsonRpcRequest } = require("src/server/dispatch-json-rpc-request");
+const { MAX_SPREAD_PERCENT } = require("src/utils/liquidity");
 
 describe("server/getters/get-categories", () => {
   let db;
@@ -21,7 +22,7 @@ describe("server/getters/get-categories", () => {
       await db("outcomes_liquidity").insert({
         marketId,
         outcome: 1,
-        spreadPercent: 0.99, // TODO 1.0
+        spreadPercent: MAX_SPREAD_PERCENT,
         liquidityTokens: 1,
       });
     }
@@ -32,9 +33,9 @@ describe("server/getters/get-categories", () => {
     }, null)).resolves.toEqual([
       {
         "categoryName": "TEST CATEGORY",
-        "nonFinalizedOpenInterest": "0",
-        "openInterest": "0",
-        "liquidityTokens": "28", // TODO BUG this is incorrect because right now we're double counting
+        "nonFinalizedOpenInterest": "4.16",
+        "openInterest": "4.16",
+        "liquidityTokens": "16",
         "tags": [
           {"nonFinalizedOpenInterest": "0", "numberOfMarketsWithThisTag": 6, "openInterest": "0", "liquidityTokens": "6", "tagName": "test tag 1"},
           {"nonFinalizedOpenInterest": "0", "numberOfMarketsWithThisTag": 6, "openInterest": "0", "liquidityTokens": "6", "tagName": "test tag 2"},
@@ -49,7 +50,7 @@ describe("server/getters/get-categories", () => {
         "categoryName": "TeSt CaTeGoRy",
         "nonFinalizedOpenInterest": "0",
         "openInterest": "0",
-        "liquidityTokens": "2", // TODO BUG this is incorrect it should be "1" because right now we're double counting
+        "liquidityTokens": "1",
         "tags": [
           {
             "nonFinalizedOpenInterest": "0",

--- a/test/unit/server/getters/get-categories.js
+++ b/test/unit/server/getters/get-categories.js
@@ -15,25 +15,58 @@ describe("server/getters/get-categories", () => {
     const params = {
       universe: "0x000000000000000000000000000000000000000b",
     };
+
+    // getCategories only returns categories that have markets that have liquidity data. Instead of making new seeds we insert seed data here.
+    for (const { marketId } of await db.select("marketId").from("markets")) {
+      await db("outcomes_liquidity").insert({
+        marketId,
+        outcome: 1,
+        spreadPercent: 0.99, // TODO 1.0
+        liquidityTokens: 1,
+      });
+    }
+
     await expect(dispatchJsonRpcRequest(db, {
       method: "getCategories",
       params,
     }, null)).resolves.toEqual([
-      {"categoryName": "AUGUR", "nonFinalizedOpenInterest": "0", "openInterest": "3", "tags": []},
-      {"categoryName": "ETHEREUM", "nonFinalizedOpenInterest": "4.5", "openInterest": "4.5", "tags": []},
-      {"categoryName": "FINANCE", "nonFinalizedOpenInterest": "2.5", "openInterest": "2.6", "tags": []},
-      {"categoryName": "POLITICS", "nonFinalizedOpenInterest": "3", "openInterest": "12", "tags": []},
-      {"categoryName": "TEST CATEGORY", "nonFinalizedOpenInterest": "0", "openInterest": "0", "tags": [
-        {"nonFinalizedOpenInterest": "0", "numberOfMarketsWithThisTag": 6, "openInterest": "0", "tagName": "test tag 1"},
-        {"nonFinalizedOpenInterest": "0", "numberOfMarketsWithThisTag": 6, "openInterest": "0", "tagName": "test tag 2"},
-        {"nonFinalizedOpenInterest": "0", "numberOfMarketsWithThisTag": 2, "openInterest": "0", "tagName": "Finance"},
-        {"nonFinalizedOpenInterest": "0", "numberOfMarketsWithThisTag": 2, "openInterest": "0", "tagName": "Augur"},
-        {"nonFinalizedOpenInterest": "0", "numberOfMarketsWithThisTag": 1, "openInterest": "0", "tagName": "politics"},
-        {"nonFinalizedOpenInterest": "0", "numberOfMarketsWithThisTag": 1, "openInterest": "0", "tagName": "ethereum"},
-        {"nonFinalizedOpenInterest": "0", "numberOfMarketsWithThisTag": 5, "openInterest": "0", "tagName": "tagging it"},
-        {"nonFinalizedOpenInterest": "0", "numberOfMarketsWithThisTag": 5, "openInterest": "0", "tagName": "tagged it"},
-      ]},
-      {"categoryName": "ethereum", "nonFinalizedOpenInterest": "0", "openInterest": "0", "tags": []},
+      {
+        "categoryName": "TEST CATEGORY",
+        "nonFinalizedOpenInterest": "0",
+        "openInterest": "0",
+        "liquidityTokens": "28", // TODO BUG this is incorrect because right now we're double counting
+        "tags": [
+          {"nonFinalizedOpenInterest": "0", "numberOfMarketsWithThisTag": 6, "openInterest": "0", "liquidityTokens": "6", "tagName": "test tag 1"},
+          {"nonFinalizedOpenInterest": "0", "numberOfMarketsWithThisTag": 6, "openInterest": "0", "liquidityTokens": "6", "tagName": "test tag 2"},
+          {"nonFinalizedOpenInterest": "0", "numberOfMarketsWithThisTag": 2, "openInterest": "0", "liquidityTokens": "2", "tagName": "Finance"},
+          {"nonFinalizedOpenInterest": "0", "numberOfMarketsWithThisTag": 2, "openInterest": "0", "liquidityTokens": "2", "tagName": "Augur"},
+          {"nonFinalizedOpenInterest": "0", "numberOfMarketsWithThisTag": 1, "openInterest": "0", "liquidityTokens": "1", "tagName": "politics"},
+          {"nonFinalizedOpenInterest": "0", "numberOfMarketsWithThisTag": 1, "openInterest": "0", "liquidityTokens": "1", "tagName": "ethereum"},
+          {"nonFinalizedOpenInterest": "0", "numberOfMarketsWithThisTag": 5, "openInterest": "0", "liquidityTokens": "5", "tagName": "tagging it"},
+          {"nonFinalizedOpenInterest": "0", "numberOfMarketsWithThisTag": 5, "openInterest": "0", "liquidityTokens": "5", "tagName": "tagged it"},
+        ]},
+      {
+        "categoryName": "TeSt CaTeGoRy",
+        "nonFinalizedOpenInterest": "0",
+        "openInterest": "0",
+        "liquidityTokens": "2", // TODO BUG this is incorrect it should be "1" because right now we're double counting
+        "tags": [
+          {
+            "nonFinalizedOpenInterest": "0",
+            "numberOfMarketsWithThisTag": 1,
+            "openInterest": "0",
+            "liquidityTokens": "1",
+            "tagName": "tEsT tag 1",
+          },
+          {
+            "nonFinalizedOpenInterest": "0",
+            "numberOfMarketsWithThisTag": 1,
+            "openInterest": "0",
+            "liquidityTokens": "1",
+            "tagName": "test tag 2",
+          },
+        ],
+      },
     ]);
   });
 


### PR DESCRIPTION
This PR completes some line items from https://github.com/AugurProject/augur/issues/2328:

1. Only show tags and categories based on what markets pass the filter. Rank tags and categories by liquidityTokens of markets within them.

2. Use 100% spread for "Liquidity - All Spreads".

3. In liquidityTokens algorithm sell a smaller increment of 0.02 ETH so that markets with less liquidity survive spread filter.