### PR TITLE
rate limit calls to ethgasstation to once per hour

### DIFF
--- a/src/utils/gas.ts
+++ b/src/utils/gas.ts
@@ -18,7 +18,7 @@ let didStart = false;
 export function startFetchingGasPrice(): void {
   if (didStart) return;
   didStart = true;
-  setInterval(fetchGasPrice, 60 * 1000);
+  setInterval(fetchGasPrice, 3600 * 1000);
   fetchGasPrice();
 }
 


### PR DESCRIPTION
reduce freq we are calling eth gas station to get gas prices. Instead of every minute change to every hour.